### PR TITLE
Update GH actions to store generated HTML as build artifact

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,3 +12,8 @@ jobs:
         uses: actions/checkout@v4
       - name: build
         run: ./repo.sh docs
+      - name: 'upload Artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-html
+          path: _build/docs/nvidia_network_operator


### PR DESCRIPTION
HTLM generated during the build can be downloaded from the build artifacts.
Example of the build:
https://github.com/ykulazhenkov/network-operator-docs/actions/runs/8184371629?pr=1