### PR TITLE
docs: add missing apiVersion to SriovNetworkNodePolicy

### DIFF
--- a/docs/getting-started-kubernetes.rst
+++ b/docs/getting-started-kubernetes.rst
@@ -1528,6 +1528,7 @@ Create SriovNetworkNodePolicy for selected NIC
 
 .. code-block:: yaml
 
+    apiVersion: sriovnetwork.openshift.io/v1
     kind: SriovNetworkNodePolicy
     metadata:
       name: ovs-switchdev
@@ -1616,6 +1617,7 @@ Create SriovNetworkNodePolicy for selected NIC
 
 .. code-block:: yaml
 
+    apiVersion: sriovnetwork.openshift.io/v1
     kind: SriovNetworkNodePolicy
     metadata:
       name: ovs-switchdev


### PR DESCRIPTION
This PR adds missing apiVersions to the `SriovNetworkNodePolicies` in the getting-started docs.