### PR TITLE
Add option to generate helm docs from local path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 TOOLSDIR=$(CURDIR)/hack/tools/bin
 BUILDDIR=$(CURDIR)/build/_output
 
-
 # If gobin not set, create one on ./build and add to path.
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(BUILD_DIR)/gobin
@@ -11,51 +10,73 @@ GOBIN=$(shell go env GOBIN)
 endif
 export PATH:=$(GOBIN):${PATH}
 
-$(TOOLSDIR):
-	@mkdir -p $@
-
-$(BUILDDIR): ; $(info Creating build directory...)
-	mkdir -p $@
-
 BRANCH ?= master
 # Paths to download the helm chart to.
-HELM_CHART_DEP_ROOT ?= $(BUILDDIR)/helmcharts
+HELM_CHART_DEP_ROOT = $(BUILDDIR)/helmcharts
 # Helm chart version and url
 HELM_CHART_VERSION ?= 24.4.1
 NGC_HELM_CHART_URL ?= https://helm.ngc.nvidia.com/nvidia/charts/network-operator-${HELM_CHART_VERSION}.tgz
 BRANCH_HELM_CHART_URL ?= https://github.com/Mellanox/network-operator/archive/refs/heads/${BRANCH}.tar.gz
+HELM_CHART_PATH ?=
+
+$(BUILDDIR) $(TOOLSDIR) $(HELM_CHART_DEP_ROOT): ; $(info Creating directory $@...)
+	mkdir -p $@
 
 # helm-docs is used to generate helm chart documentation
 HELM_DOCS_PKG := github.com/norwoodj/helm-docs/cmd/helm-docs
 HELM_DOCS_VER := v1.14.2
 HELM_DOCS_BIN := helm-docs
-HELM_DOCS_PATH = $(abspath $(TOOLSDIR)/$(HELM_DOCS_BIN))
 HELM_DOCS = $(abspath $(TOOLSDIR)/$(HELM_DOCS_BIN))-$(HELM_DOCS_VER)
 $(HELM_DOCS): | $(TOOLSDIR)
 	$(call go-install-tool,$(HELM_DOCS_PKG),$(HELM_DOCS_BIN),$(HELM_DOCS_VER))
-	$Q ln $(HELM_DOCS) $(HELM_DOCS_PATH)
 
 # go-install-tool will 'go install' a go module $1 with version $3 and install it with the name $2-$3 to $TOOLSDIR.
 define go-install-tool
-	$Q echo "Installing $(2)-$(3) to $(TOOLSDIR)"
-	$Q GOBIN=$(TOOLSDIR) go install $(1)@$(3)
-	$Q mv $(TOOLSDIR)/$(2) $(TOOLSDIR)/$(2)-$(3)
+	echo "Installing $(2)-$(3) to $(TOOLSDIR)"
+	GOBIN=$(TOOLSDIR) go install $(1)@$(3)
+	mv $(TOOLSDIR)/$(2) $(TOOLSDIR)/$(2)-$(3)
 endef
 
-download-ngc-helm-chart:
-	mkdir -p ${HELM_CHART_DEP_ROOT} && cd ${HELM_CHART_DEP_ROOT} \
+.PHONY: clean-helm-chart-dep-root
+clean-helm-chart-dep-root:
+	rm -rf ${HELM_CHART_DEP_ROOT}/*
+
+.PHONY: download-ngc-helm-chart
+download-ngc-helm-chart: | $(HELM_CHART_DEP_ROOT) clean-helm-chart-dep-root
+	cd ${HELM_CHART_DEP_ROOT} \
 	&& curl -sL ${NGC_HELM_CHART_URL} | tar -xz
 
-download-branch-helm-chart:
-	mkdir -p ${HELM_CHART_DEP_ROOT} \
-	&& curl -sL ${BRANCH_HELM_CHART_URL} \
+.PHONY: download-branch-helm-chart
+download-branch-helm-chart: | $(HELM_CHART_DEP_ROOT) clean-helm-chart-dep-root
+	curl -sL ${BRANCH_HELM_CHART_URL} \
 	| tar -xz -C ${HELM_CHART_DEP_ROOT} \
 	--strip-components 2 network-operator-${BRANCH}/deployment/network-operator
 
-# Generate helm chart documentation in a reStructuredText format.
-helm-docs: $(HELM_DOCS)
-	$(HELM_DOCS) --output-file=../../../../docs/customizations/helm.rst --ignore-file=.helmdocsignore --template-files=./templates/helm.rst.gotmpl ${HELM_CHART_DEP_ROOT}
+.PHONY: copy-local-helm-chart
+copy-local-helm-chart: | $(HELM_CHART_DEP_ROOT) clean-helm-chart-dep-root
+	@if [ ! -d $(HELM_CHART_PATH) ] || [ -z $(HELM_CHART_PATH) ]; \
+		then echo "HELM_CHART_PATH is not a directory"; \
+		exit 1; \
+	fi
+	cp -r $(HELM_CHART_PATH) $(HELM_CHART_DEP_ROOT)
 
+# Generate helm chart documentation in a reStructuredText format.
+.PHONY: helm-docs
+helm-docs: | $(HELM_DOCS)
+	$(HELM_DOCS) --output-file=../../../../docs/customizations/helm.rst \
+	--ignore-file=.helmdocsignore \
+	--template-files=./templates/helm.rst.gotmpl \
+	--chart-search-root ${HELM_CHART_DEP_ROOT}
+
+.PHONY: ngc-helm-docs
 ngc-helm-docs: download-ngc-helm-chart helm-docs
 
+.PHONY: branch-helm-docs
 branch-helm-docs: download-branch-helm-chart helm-docs
+
+.PHONY: local-helm-docs
+local-helm-docs: copy-local-helm-chart helm-docs
+
+.PHONY: gen-docs
+gen-docs:
+	@ ./repo.sh docs

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ https://mellanox.github.io/network-operator-docs/
 To generate the docs run:
 
 ```bash
-./repo.sh docs
+make gen-docs
 ```
 
 Generated files will be under `_build/docs/nvidia_network_operator/latest/`


### PR DESCRIPTION
Add new makefile targets to enable this workflow
user should run:

`HELM_CHART_PATH=/path/to/network-operator/local/chart make local-helm-docs`

In addition perform some Makefile cleanup/maintenance