### PR TITLE
update docs with nvme storage modules limitations

### DIFF
--- a/docs/customizations/helm.rst
+++ b/docs/customizations/helm.rst
@@ -208,7 +208,7 @@ SR-IOV Network Operator Helm chart customization options can be found `here <htt
      -
    * - sriov-network-operator.images.operator
      - string
-     - `"nvcr.io/nvstaging/mellanox/sriov-network-operator:network-operator-24.7.0-beta.3"`
+     - `"nvcr.io/nvstaging/mellanox/sriov-network-operator:network-operator-24.7.0-beta.4"`
      -
    * - sriov-network-operator.images.ovsCni
      - string
@@ -224,7 +224,7 @@ SR-IOV Network Operator Helm chart customization options can be found `here <htt
      -
    * - sriov-network-operator.images.sriovConfigDaemon
      - string
-     - `"nvcr.io/nvstaging/mellanox/sriov-network-operator-config-daemon:network-operator-24.7.0-beta.3"`
+     - `"nvcr.io/nvstaging/mellanox/sriov-network-operator-config-daemon:network-operator-24.7.0-beta.4"`
      -
    * - sriov-network-operator.images.sriovDevicePlugin
      - string
@@ -232,7 +232,7 @@ SR-IOV Network Operator Helm chart customization options can be found `here <htt
      -
    * - sriov-network-operator.images.webhook
      - string
-     - `"nvcr.io/nvstaging/mellanox/sriov-network-operator-webhook:network-operator-24.7.0-beta.3"`
+     - `"nvcr.io/nvstaging/mellanox/sriov-network-operator-webhook:network-operator-24.7.0-beta.4"`
      -
    * - sriov-network-operator.operator.admissionControllers
      - object
@@ -403,7 +403,7 @@ For example:
      -
    * - ofedDriver.version
      - string
-     - `"24.07-0.4.7.0-0"`
+     - `"24.07-0.6.0.0-1"`
      - NVIDIA DOCA Driver version.
 
 ===============================================
@@ -433,7 +433,7 @@ The following are special environment variables supported by the NVIDIA DOCA Dri
        |    * ib_srpt
    * - ENABLE_NFSRDMA
      - "false"
-     - Enable loading of NFS related storage modules from a NVIDIA DOCA Driver container
+     - Enable loading of NFS & NVME related storage modules from a NVIDIA DOCA Driver container
    * - RESTORE_DRIVER_ON_POD_TERMINATION
      - "true"
      - Restore host drivers when a container
@@ -442,6 +442,10 @@ In addition, it is possible to specify any environment variables to be exposed t
 
 .. warning::
    CREATE_IFNAMES_UDEV is set automatically by the Network Operator, depending on the Operating System of the worker nodes in the cluster (the cluster is assumed to be homogenous).
+
+.. warning::
+  When ENABLE_NFSRDMA is set to `true`, it is not possible to load NVME related storage modules from NVIDIA DOCA Driver container when they are in use by the system
+  (e.g the system has NVMe SSD drives in use). User should ensure the modules are not in use and blacklist them prior to the use of NVIDIA DOCA Driver container.
 
 To set these variables, change them into Helm values. For example:
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -181,6 +181,10 @@ Known Limitations
 
    * - Version
      - Description
+   * - 24.7.0
+     -  - In case ENABLE_NFSRDMA is enabled for DOCA Driver container and NVMe modules are loaded in the host system, NVIDA DOCA Driver Container will fail to load. User should
+          blacklist NVMe modules to prevent them from loading on system boot. if this is not possible (e.g when the system uses NVMe SSD drives) then ENABLE_NFSRDMA must
+          be set to `false`. Using features such as GPU Direct Storage is not supported in such case. 
    * - 23.10.0
      - | - IPoIB sub-interface creation does not work on RHEL 8.8 and RHEL 9.2 due to the kernel limitations in these distributions. This means that IPoIBNetwork cannot be used with these operating systems.
    * - 23.4.0

--- a/templates/helm.rst.gotmpl
+++ b/templates/helm.rst.gotmpl
@@ -208,7 +208,7 @@ The following are special environment variables supported by the NVIDIA DOCA Dri
        |    * ib_srpt
    * - ENABLE_NFSRDMA
      - "false"
-     - Enable loading of NFS related storage modules from a NVIDIA DOCA Driver container
+     - Enable loading of NFS & NVME related storage modules from a NVIDIA DOCA Driver container
    * - RESTORE_DRIVER_ON_POD_TERMINATION
      - "true"
      - Restore host drivers when a container
@@ -217,6 +217,10 @@ In addition, it is possible to specify any environment variables to be exposed t
 
 .. warning::
    CREATE_IFNAMES_UDEV is set automatically by the Network Operator, depending on the Operating System of the worker nodes in the cluster (the cluster is assumed to be homogenous).
+
+.. warning::
+  When ENABLE_NFSRDMA is set to `true`, it is not possible to load NVME related storage modules from NVIDIA DOCA Driver container when they are in use by the system
+  (e.g the system has NVMe SSD drives in use). User should ensure the modules are not in use and blacklist them prior to the use of NVIDIA DOCA Driver container.
 
 To set these variables, change them into Helm values. For example:
 


### PR DESCRIPTION
if nvme driver is loaded in the host system doca driver container will fail if ENABLE_NFSRDMA is set to true.

document this limitation.