### PR TITLE
feat: add ci for making docs

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -1,0 +1,59 @@
+name: documentation CI
+
+on:
+  workflow_call:
+    inputs:
+      git_tag:
+        type: string
+        description: The git tag (version) from the calling workflow
+        required: true
+  workflow_dispatch:
+    inputs:
+      git_tag:
+        type: string
+        description: The git tag (version) to use for `$TAG`
+        required: true
+
+jobs:
+  docs-ci:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN_NVIDIA_CI_CD }}
+      TAG: ${{ inputs.git_tag }}
+      PR_TITLE_PREFIX: "task: update documentation for"
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GH_TOKEN_NVIDIA_CI_CD }}  # token must be explicitly set here for push to work in following step
+    - name: Make docs
+      run: |
+        make helm-docs api-docs generate-docs-versions-var doca-driver-build-update
+    - name: Close any existing documentation PRs
+      run: |
+        for pr_number in $(gh pr list --search "$PR_TITLE_PREFIX" --json number --jq ".[].number"); do
+          gh pr close $pr_number
+        done
+    - name: Create PR
+      env:
+        DOWNSTREAM_REPO_OWNER: nvidia-ci-cd
+        DOWNSTREAM_FEATURE_BRANCH: update-docs-for-${{ env.TAG }}
+        UPSTREAM_REPO_OWNER: Mellanox
+        UPSTREAM_DEFAULT_BRANCH: main
+        COMMIT_MESSAGE: ${{ env.PR_TITLE_PREFIX }} ${{ env.TAG }}
+      run: |
+        git config user.name  nvidia-ci-cd
+        git config user.email svc-cloud-orch-gh@nvidia.com
+        gh repo fork --remote --default-branch-only
+        gh repo sync $DOWNSTREAM_REPO_OWNER/${{ github.event.repository.name }} --source $UPSTREAM_REPO_OWNER/${{ github.event.repository.name }} --branch $UPSTREAM_DEFAULT_BRANCH
+
+        git checkout -b $DOWNSTREAM_FEATURE_BRANCH
+        git status
+        git add docs
+        git commit -m "$COMMIT_MESSAGE"
+
+        git push -u origin $DOWNSTREAM_FEATURE_BRANCH
+        gh pr create \
+          --head $DOWNSTREAM_REPO_OWNER:$DOWNSTREAM_FEATURE_BRANCH \
+          --base $UPSTREAM_DEFAULT_BRANCH \
+          --title "$COMMIT_MESSAGE" \
+          --body "Created by the *${{ github.job }}* job in [${{ github.repository }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."


### PR DESCRIPTION
Note: This workflow shall be triggered from the https://github.com/Mellanox/network-operator repository ([additional PR](https://github.com/Mellanox/network-operator/pull/1045) there).