### PR TITLE
Fixing CI Documentation workflow

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -49,7 +49,7 @@ jobs:
         git config user.name  nvidia-ci-cd
         git config user.email svc-cloud-orch-gh@nvidia.com
         gh repo fork --remote --default-branch-only
-        gh repo sync $DOWNSTREAM_REPO_OWNER/${{ github.event.repository.name }} --source $UPSTREAM_REPO_OWNER/${{ github.event.repository.name }} --branch $UPSTREAM_DEFAULT_BRANCH
+        gh repo sync $DOWNSTREAM_REPO_OWNER/network-operator-docs --source $UPSTREAM_REPO_OWNER/network-operator-docs --branch $UPSTREAM_DEFAULT_BRANCH
 
         git checkout -b $DOWNSTREAM_FEATURE_BRANCH
         git status


### PR DESCRIPTION
Fixing failed (404 Not found) 'gh repo sync' since it was trying to fork 'network-operator' instead of 'network-operator-docs' repo

```
2024-11-03T08:13:23.6882567Z   GH_TOKEN: ***
2024-11-03T08:13:23.6882924Z   TAG: v24.10.0-beta.5
2024-11-03T08:13:23.6883409Z   PR_TITLE_PREFIX: task: update documentation for
2024-11-03T08:13:23.6883856Z   DOWNSTREAM_REPO_OWNER: nvidia-ci-cd
2024-11-03T08:13:23.6884379Z   DOWNSTREAM_FEATURE_BRANCH: update-docs-for-v24.10.0-beta.5
2024-11-03T08:13:23.6884955Z   UPSTREAM_REPO_OWNER: Mellanox
2024-11-03T08:13:23.6885390Z   UPSTREAM_DEFAULT_BRANCH: main
2024-11-03T08:13:23.6885949Z   COMMIT_MESSAGE: task: update documentation for v24.10.0-beta.5
2024-11-03T08:13:23.6886451Z ##[endgroup]
2024-11-03T08:13:24.1301934Z nvidia-ci-cd/network-operator-docs already exists
2024-11-03T08:13:24.4257923Z HTTP 404: Not Found (https://api.github.com/repos/nvidia-ci-cd/network-operator/merge-upstream)
2024-11-03T08:13:24.4284417Z ##[error]Process completed with exit code 1.
```