### PR TITLE
bug: fix resource name in HostDeviceNetwork

### DIFF
--- a/docs/getting-started-kubernetes.rst
+++ b/docs/getting-started-kubernetes.rst
@@ -535,7 +535,7 @@ The ``host-device-net.yaml`` configuration file for such a deployment:
       name: hostdev-net
     spec:
       networkNamespace: "default"
-      resourceName: "nvidia.com/hostdev"
+      resourceName: "hostdev"
       ipam: |
         {
           "type": "whereabouts",
@@ -562,7 +562,7 @@ The ``host-device-net-ocp.yaml`` configuration file for such a deployment in the
       name: hostdev-net
     spec:
       networkNamespace: "default"
-      resourceName: "nvidia.com/hostdev"
+      resourceName: "hostdev"
       ipam: |
         {
           "type": "whereabouts",

--- a/docs/getting-started-openshift.rst
+++ b/docs/getting-started-openshift.rst
@@ -286,7 +286,7 @@ The `host-device-net.yaml`` configuration file for such a deployment:
      name: hostdev-net
    spec:
      networkNamespace: "default"
-     resourceName: "nvidia.com/hostdev"
+     resourceName: "hostdev"
      ipam: |
        {
          "type": "whereabouts",


### PR DESCRIPTION
Following example from Network Operator:
https://github.com/Mellanox/network-operator/blob/master/example/crs/mellanox.com_v1alpha1_hostdevicenetwork_cr-ocp.yaml#L20