### PR TITLE
bug: remove empty config in multus examples

### DIFF
--- a/docs/customizations/cr-full-example.rst
+++ b/docs/customizations/cr-full-example.rst
@@ -104,7 +104,6 @@ This example should serve as a reference, it is not recommended to apply it as i
           image: multus-cni
           repository: ghcr.io/k8snetworkplumbingwg
           version: |multus-version|
-          config: ''
         ipamPlugin:
           image: whereabouts
           repository: ghcr.io/k8snetworkplumbingwg


### PR DESCRIPTION
Empty config in multus, empty multus config is created causing nodes to be in not ready state.