### PR TITLE
add Platform Support note about FW resets on BMC-controlled platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,39 @@ gen-docs: build-cache
     export PM_PACKAGES_ROOT=${CACHE_DIR}; \
 	${CURDIR}/repo.sh docs
 
+DOCKER_DOCS_IMAGE ?= network-operator-docs-builder:local
+DOCKER_DOCS_DOCKERFILE ?= hack/Dockerfile.docs
+
+# Build (or refresh) the docs-builder image. Docker's layer cache keeps this
+# fast on no-op runs; edits to the Dockerfile trigger a rebuild automatically.
+.PHONY: gen-docs-docker-image
+gen-docs-docker-image:
+	docker build --platform=linux/amd64 \
+		-t $(DOCKER_DOCS_IMAGE) \
+		-f $(DOCKER_DOCS_DOCKERFILE) hack/
+
+# Run gen-docs inside a Linux container. Required on macOS where NVIDIA's
+# Packman/repoman tooling rejects the host platform. Pinned to linux/amd64
+# because Packman ships sphinx for linux-x86_64 only (arm64 Python exists
+# but not arm64 sphinx). On Apple Silicon this runs under emulation.
+#
+# State retained between builds:
+#   - apt-installed system deps live in the docker image ($(DOCKER_DOCS_IMAGE))
+#   - Packman cache persists in $(CACHE_DIR) via the bind-mount
+#   - Sphinx output persists in _build/ via the bind-mount
+# To force a clean rebuild of the image: docker rmi $(DOCKER_DOCS_IMAGE)
+.PHONY: gen-docs-docker
+gen-docs-docker: gen-docs-docker-image
+	docker run --rm \
+		--platform=linux/amd64 \
+		--volume "$(CURDIR):/work" \
+		--workdir /work \
+		--env HOME=/tmp \
+		--env HOST_UID=$(shell id -u) \
+		--env HOST_GID=$(shell id -g) \
+		$(DOCKER_DOCS_IMAGE) \
+		bash -lc 'trap "chown -R $$HOST_UID:$$HOST_GID /work" EXIT; make gen-docs'
+
 .PHONY: generate-docs-versions-var
 generate-docs-versions-var: | $(BUILDDIR)
 	curl -sL ${RELEASE_YAML_URL} -o $(CURDIR)/build/release.yaml

--- a/docs/nic-conf-operator/nic-fw-configuration.rst
+++ b/docs/nic-conf-operator/nic-fw-configuration.rst
@@ -78,6 +78,76 @@ There are two requirements for the SR-IOV Network Operator to work together with
 .. warning::
    SR-IOV Network Operator can work together with the NIC Configuration Operator only in ``daemon`` configuration mode. ``systemd`` configuration mode is not supported with this scenario.
 
+.. _fw-reset-external-bmc:
+
+=====================================================================
+Platforms with external BMC (DGX, HGX GB200/B200/B300, Vera Rubin GB)
+=====================================================================
+
+On platforms where the NIC is controlled by an external BMC — including NVIDIA DGX and HGX systems (GB200 NVL72, B200, B300) and the Vera Rubin GB family — an OS-level node reboot does **not** reload NIC firmware: the BMC keeps the device powered across the reboot. As a result, persistent firmware parameters set with ``mlxconfig`` are not applied, and the operator stack can end up in a reboot loop trying to converge on the requested configuration.
+
+To avoid this, configure both the NIC Configuration Operator and the SR-IOV Network Operator to perform an explicit firmware reset (``mlxfwreset`` / ``mstfwreset``) **before** the reboot. The two settings are independent — enable both when both operators are deployed, or just the one matching the operator you are running.
+
+.. note::
+   ``NicConfigurationTemplate`` and ``SriovNetworkNodePolicy`` resources do not require any platform-specific changes. The firmware-reset behavior is controlled at the operator level only.
+
+-------------------------------------------------------------
+NIC Configuration Operator (``FW_RESET_AFTER_CONFIG_UPDATE``)
+-------------------------------------------------------------
+
+Set the ``FW_RESET_AFTER_CONFIG_UPDATE`` environment variable to ``"true"`` on the ``nicConfigurationOperator`` section of your ``NicClusterPolicy``. The configuration daemon will then run ``mlxfwreset`` on each managed NIC after applying non-volatile configuration, before draining and rebooting the node.
+
+.. code-block:: yaml
+    :substitutions:
+
+    apiVersion: mellanox.com/v1alpha1
+    kind: NicClusterPolicy
+    metadata:
+      name: nic-cluster-policy
+    spec:
+      nicConfigurationOperator:
+        operator:
+          image: nic-configuration-operator
+          repository: |nic-configuration-operator-repository|
+          version: |nic-configuration-operator-version|
+        configurationDaemon:
+          image: nic-configuration-operator-daemon
+          repository: |nic-configuration-operator-repository|
+          version: |nic-configuration-operator-version|
+        env:
+        - name: "FW_RESET_AFTER_CONFIG_UPDATE"
+          value: "true"
+
+----------------------------------------------------------------
+SR-IOV Network Operator (``mellanoxFirmwareReset`` feature gate)
+----------------------------------------------------------------
+
+Enable the ``mellanoxFirmwareReset`` feature gate on the ``SriovOperatorConfig``. The SR-IOV config daemon will then invoke ``mstfwreset`` against the Mellanox NIC before triggering the reboot, so that firmware parameters changed by the SR-IOV plugin (for example ``SRIOV_EN``, ``NUM_OF_VFS``) take effect on external-BMC platforms.
+
+When deploying via the Network Operator Helm chart, set the feature gate via Helm values:
+
+``values.yaml``:
+
+.. code-block:: yaml
+
+    sriovNetworkOperator:
+      enabled: true
+    sriov-network-operator:
+      sriovOperatorConfig:
+        featureGates:
+          mellanoxFirmwareReset: true
+
+For an already-installed cluster, patch the ``SriovOperatorConfig`` directly:
+
+.. code-block:: bash
+
+   kubectl patch sriovoperatorconfigs.sriovnetwork.openshift.io \
+     -n nvidia-network-operator default \
+     --patch '{"spec":{"featureGates":{"mellanoxFirmwareReset":true}}}' \
+     --type=merge
+
+The ``mellanoxFirmwareReset`` feature gate is documented as Beta in the upstream SR-IOV Network Operator project — see the `SR-IOV Network Operator API documentation <https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/doc/api/operator-config-api.md>`_ for details.
+
 =============================================================================
 Install the NIC Configuration Operator and observe NIC devices in the cluster
 =============================================================================
@@ -89,7 +159,7 @@ Install the NIC Configuration Operator and observe NIC devices in the cluster
     To disable the Firmware upgrade and validation logic, do not define the ``nicFirmwareStorage`` section in the NicClusterPolicy CR.
 
 .. note::
-    On some DGX servers, the configuration update is not successfully applied after the warm reboot. In this case, it is recommended to explicitly reset the NIC's Firmware before the reboot and after updating its non-volatile configuration. This can be achieved by specifying the ``FW_RESET_AFTER_CONFIG_UPDATE`` environment variable in the NicClusterPolicy CR. Please see the commented section in the example below.
+    On platforms where the NIC is controlled by an external BMC (DGX, HGX GB200/B200/B300, Vera Rubin GB), additional configuration is required so that firmware updates are applied without a reboot loop — see :ref:`fw-reset-external-bmc`. The example below shows the relevant ``FW_RESET_AFTER_CONFIG_UPDATE`` knob commented out for reference.
 
 First install the Network Operator helm chart with the Maintenance Operator enabled and deploy a NIC Cluster Policy CRD with NIC Configuration Operator and DOCA-OFED Driver enabled:
 

--- a/docs/platform-support.rst
+++ b/docs/platform-support.rst
@@ -128,13 +128,13 @@ The following NVIDIA Data Center systems have been tested and validated with **N
      - NVIDIA Blackwell
      - ConnectX-7
      - Ubuntu 24.04 (ARM64) / Red Hat OpenShift
-     - GA
+     - GA. Mellanox Firmware Reset required (see :ref:`fw-reset-external-bmc`)
    * - NVIDIA DGX/HGX B200
      - x86
      - NVIDIA Blackwell
      - BlueField-3 SuperNIC (NIC mode) / ConnectX-7
      - Ubuntu 22.04 / 24.04 (x86) / Red Hat OpenShift
-     - GA
+     - GA. Mellanox Firmware Reset required (see :ref:`fw-reset-external-bmc`)
    * - NVIDIA RTX PRO 6000 Blackwell Server
      - x86
      - NVIDIA Blackwell
@@ -146,7 +146,7 @@ The following NVIDIA Data Center systems have been tested and validated with **N
      - NVIDIA Blackwell
      - ConnectX-8 SuperNIC
      - Ubuntu 22.04 / 24.04 (x86) / Red Hat OpenShift
-     - GA
+     - GA. Mellanox Firmware Reset required (see :ref:`fw-reset-external-bmc`)
 
 ====================================================
 Supported Operating Systems and Kubernetes Platforms

--- a/hack/Dockerfile.docs
+++ b/hack/Dockerfile.docs
@@ -1,0 +1,12 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+        make curl git \
+        python3 python3-pip python3-venv \
+        ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work


### PR DESCRIPTION
+ support for `make gen-docs-docker` for mac