### PR TITLE
docs: fix Network Operator 23.1.0 release notes heading

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -128,7 +128,7 @@ Changes and New Features
      - | - Added support for Kubernetes >= 1.21 and <=1.27
        | - Added support for NicClusterPolicy update and removal
        | - Added support for OpenShift Container Platform 4.11 and 4.12
-   * - 23.4.0
+   * - 23.1.0
      - | - Added a calendar versioning schema for Network Operator releases to better align with the NVIDIA GPU Operator
        | - Added support for the following operating systems and Kubernetes environments:
        |     - RHEL 8.4 and 8.6 with CRI-O container runtime


### PR DESCRIPTION
## Summary
- Relabel the second duplicate `23.4.0` entry in Network Operator release notes to `23.1.0`.
- Keep the feature bullets unchanged.

## Rationale
The v23.1.0 WWFO announcement sent on 2023-02-23T22:31Z matches the bullets in this release-notes row: calendar versioning, RHEL 8.4/8.6 with CRI-O, Kubernetes 1.21-1.26, PKey configuration, and graceful OFED container termination on DGX OpenShift.

## Validation
- `git diff --check`
