### PR TITLE
docs: use envsubst for quick-start examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,17 +176,23 @@ build-cache:
 .PHONY: process-examples
 process-examples: | $(EXAMPLES_BUILD_DIR)
 	@echo "Processing YAML examples with version substitutions..."
-	@# Generate sed script from all variables in vars.rst
-	@grep -E '^\.\. \|.*\| replace::' docs/common/vars.rst | \
-		sed 's/\.\. |\(.*\)| replace:: \(.*\)/s@|\1|@\2@g/' > /tmp/vars.sed
-	@find examples/templates -name "*.yaml" -type f | while read -r file; do \
+	@command -v envsubst >/dev/null || { echo "envsubst is required for process-examples"; exit 1; }
+	@vars_env=$$(mktemp); \
+	grep -E '^\.\. \|.*\| replace::' docs/common/vars.rst | while read -r line; do \
+		name=$$(printf '%s\n' "$$line" | sed -E 's/^\.\. \|([^|]+)\| replace:: .*/\1/' | tr '[:lower:]-' '[:upper:]_'); \
+		value=$$(printf '%s\n' "$$line" | sed -E 's/^\.\. \|[^|]+\| replace:: //'); \
+		escaped_value=$$(printf '%s\n' "$$value" | sed "s/'/'\\\\''/g"); \
+		printf "export %s='%s'\n" "$$name" "$$escaped_value"; \
+	done > "$$vars_env"; \
+	set -a; . "$$vars_env"; set +a; \
+	rm -f "$$vars_env"; \
+	find examples/templates -name "*.yaml" -type f | while read -r file; do \
 		echo "Processing $$file"; \
 		relative_path=$$(echo "$$file" | sed 's|^examples/templates/||'); \
 		output_dir="$(EXAMPLES_BUILD_DIR)/$$(dirname "$$relative_path")"; \
 		mkdir -p "$$output_dir"; \
-		sed -f /tmp/vars.sed "$$file" > "$(EXAMPLES_BUILD_DIR)/$$relative_path"; \
+		envsubst < "$$file" > "$(EXAMPLES_BUILD_DIR)/$$relative_path"; \
 	done
-	@rm -f /tmp/vars.sed
 	@echo "Generating complete configuration files..."
 	@# Generate complete.yaml files by concatenating numbered files in order
 	@find $(EXAMPLES_BUILD_DIR) -mindepth 1 -maxdepth 1 -type d | while read -r dir; do \

--- a/examples/templates/host-device-rdma/10-nicclusterpolicy.yaml
+++ b/examples/templates/host-device-rdma/10-nicclusterpolicy.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   sriovDevicePlugin:
     image: sriov-network-device-plugin
-    repository: |sriovnetop-sriov-device-plugin-repository|
-    version: |sriovnetop-sriov-device-plugin-version|
+    repository: $SRIOVNETOP_SRIOV_DEVICE_PLUGIN_REPOSITORY
+    version: $SRIOVNETOP_SRIOV_DEVICE_PLUGIN_VERSION
     config: |
       {
         "resourceList": [
@@ -22,16 +22,16 @@ spec:
       }
   nvIpam:
     image: nvidia-k8s-ipam
-    repository: |nvidia-ipam-repository|
-    version: |nvidia-ipam-version|
+    repository: $NVIDIA_IPAM_REPOSITORY
+    version: $NVIDIA_IPAM_VERSION
     imagePullSecrets: []
     enableWebhook: false
   secondaryNetwork:
     cniPlugins:
       image: plugins
-      repository: |cni-plugins-repository|
-      version: |cni-plugins-version|
+      repository: $CNI_PLUGINS_REPOSITORY
+      version: $CNI_PLUGINS_VERSION
     multus:
       image: multus-cni
-      repository: |multus-repository|
-      version: |multus-version|
+      repository: $MULTUS_REPOSITORY
+      version: $MULTUS_VERSION

--- a/examples/templates/ipoib-rdma-shared/10-nicclusterpolicy.yaml
+++ b/examples/templates/ipoib-rdma-shared/10-nicclusterpolicy.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   ofedDriver:
     image: doca-driver
-    repository: |doca-driver-repository|
-    version: |doca-driver-version|
+    repository: $DOCA_DRIVER_REPOSITORY
+    version: $DOCA_DRIVER_VERSION
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
-    repository: |k8s-rdma-shared-dev-plugin-repository|
-    version: |k8s-rdma-shared-dev-plugin-version|
+    repository: $K8S_RDMA_SHARED_DEV_PLUGIN_REPOSITORY
+    version: $K8S_RDMA_SHARED_DEV_PLUGIN_VERSION
     config: |
       {
         "configList": [
@@ -39,20 +39,20 @@ spec:
       }
   nvIpam:
     image: nvidia-k8s-ipam
-    repository: |nvidia-ipam-repository|
-    version: |nvidia-ipam-version|
+    repository: $NVIDIA_IPAM_REPOSITORY
+    version: $NVIDIA_IPAM_VERSION
     imagePullSecrets: []
     enableWebhook: false
   secondaryNetwork:
     cniPlugins:
       image: plugins
-      repository: |cni-plugins-repository|
-      version: |cni-plugins-version|
+      repository: $CNI_PLUGINS_REPOSITORY
+      version: $CNI_PLUGINS_VERSION
     multus:
       image: multus-cni
-      repository: |multus-repository|
-      version: |multus-version|
+      repository: $MULTUS_REPOSITORY
+      version: $MULTUS_VERSION
     ipoib:
       image: ipoib-cni
-      repository: |ipoib-cni-repository|
-      version: |ipoib-cni-version|
+      repository: $IPOIB_CNI_REPOSITORY
+      version: $IPOIB_CNI_VERSION

--- a/examples/templates/macvlan-rdma-shared/10-nicclusterpolicy.yaml
+++ b/examples/templates/macvlan-rdma-shared/10-nicclusterpolicy.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
-    repository: |k8s-rdma-shared-dev-plugin-repository|
-    version: |k8s-rdma-shared-dev-plugin-version|
+    repository: $K8S_RDMA_SHARED_DEV_PLUGIN_REPOSITORY
+    version: $K8S_RDMA_SHARED_DEV_PLUGIN_VERSION
     config: |
       {
         "configList": [
@@ -21,16 +21,16 @@ spec:
       }
   nvIpam:
     image: nvidia-k8s-ipam
-    repository: |nvidia-ipam-repository|
-    version: |nvidia-ipam-version|
+    repository: $NVIDIA_IPAM_REPOSITORY
+    version: $NVIDIA_IPAM_VERSION
     imagePullSecrets: []
     enableWebhook: false
   secondaryNetwork:
     cniPlugins:
       image: plugins
-      repository: |cni-plugins-repository|
-      version: |cni-plugins-version|
+      repository: $CNI_PLUGINS_REPOSITORY
+      version: $CNI_PLUGINS_VERSION
     multus:
       image: multus-cni
-      repository: |multus-repository|
-      version: |multus-version|
+      repository: $MULTUS_REPOSITORY
+      version: $MULTUS_VERSION

--- a/examples/templates/sriov-ib-rdma/10-nicclusterpolicy.yaml
+++ b/examples/templates/sriov-ib-rdma/10-nicclusterpolicy.yaml
@@ -5,20 +5,20 @@ metadata:
 spec:
   ofedDriver:
     image: doca-driver
-    repository: |doca-driver-repository|
-    version: |doca-driver-version|
+    repository: $DOCA_DRIVER_REPOSITORY
+    version: $DOCA_DRIVER_VERSION
   nvIpam:
     image: nvidia-k8s-ipam
-    repository: |nvidia-ipam-repository|
-    version: |nvidia-ipam-version|
+    repository: $NVIDIA_IPAM_REPOSITORY
+    version: $NVIDIA_IPAM_VERSION
     imagePullSecrets: []
     enableWebhook: false
   secondaryNetwork:
     cniPlugins:
       image: plugins
-      repository: |cni-plugins-repository|
-      version: |cni-plugins-version|
+      repository: $CNI_PLUGINS_REPOSITORY
+      version: $CNI_PLUGINS_VERSION
     multus:
       image: multus-cni
-      repository: |multus-repository|
-      version: |multus-version|
+      repository: $MULTUS_REPOSITORY
+      version: $MULTUS_VERSION

--- a/examples/templates/sriov-network-rdma/10-nicclusterpolicy.yaml
+++ b/examples/templates/sriov-network-rdma/10-nicclusterpolicy.yaml
@@ -5,15 +5,15 @@ metadata:
 spec:
   nvIpam:
     image: nvidia-k8s-ipam
-    repository: |nvidia-ipam-repository|
-    version: |nvidia-ipam-version|
+    repository: $NVIDIA_IPAM_REPOSITORY
+    version: $NVIDIA_IPAM_VERSION
     enableWebhook: false
   secondaryNetwork:
     cniPlugins:
       image: plugins
-      repository: |cni-plugins-repository|
-      version: |cni-plugins-version|
+      repository: $CNI_PLUGINS_REPOSITORY
+      version: $CNI_PLUGINS_VERSION
     multus:
       image: multus-cni
-      repository: |multus-repository|
-      version: |multus-version|
+      repository: $MULTUS_REPOSITORY
+      version: $MULTUS_VERSION


### PR DESCRIPTION
## Summary
- Switches quick-start example processing from a generated per-variable `sed` script to `envsubst`.
- Converts the YAML example templates from reStructuredText substitution tokens to shell-style variables, e.g. `$NVIDIA_IPAM_REPOSITORY`.
- Keeps the generated `examples/processed` output stable for the current `docs/common/vars.rst` values.

Addresses #238.

## Verification
- PowerShell parity check that parses `docs/common/vars.rst`, renders all `examples/templates/**/*.yaml` shell variables, and compares the result to the checked-in `examples/processed/**/*.yaml` files: passed.
- `git diff --check`: passed; Git reported only local Windows LF-to-CRLF working-copy warnings.

I could not run `make process-examples` in this local Windows environment because `make`, `bash`, and `envsubst` are not available here.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed before submission.