### PR TITLE
docs/spectrum-x: align with v26.4.x + RA 2.2 and refactor components page

### DIFF
--- a/docs/ai-skills.rst
+++ b/docs/ai-skills.rst
@@ -55,9 +55,9 @@ Each skill is a self-contained Markdown document in the `k8s-launch-kit reposito
    * - ``k8s-launch-kit-dryrun``
      - Wraps ``l8k generate --dry-run``: previews what would land on the cluster without applying.
    * - ``k8s-launch-kit-deploy``
-     - Wraps ``l8k deploy``: applies pre-generated manifests in dependency order.
+     - Wraps ``l8k deploy``: applies pre-generated manifests in four phases (NicClusterPolicy → NicNodePolicy → remaining batch → verify reconciliation). Supports ``--verify`` to chain the data-plane connectivity matrix straight after a successful apply, and ``--deploy-timeout`` to bound the whole run end-to-end.
    * - ``k8s-launch-kit-validate``
-     - Wraps ``l8k validate``: confirms the deployed Network Operator matches the selected release and every rendered manifest is present.
+     - Wraps ``l8k validate``: classifies every manifest's cluster state (READY / IN-PROGRESS / ERROR / MISSING), runs a connectivity ping matrix between the example DaemonSet's pods on every rail (default ON; ``--connectivity=false`` to skip), and writes an HTML validation report to ``<deployment-files>/verify-report.html``.
    * - ``k8s-launch-kit-pipeline``
      - End-to-end orchestration (discover → generate → deploy) for greenfield clusters.
    * - ``k8s-launch-kit-troubleshoot``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@
    Getting Started with Red Hat OpenShift <getting-started-with-openshift.rst>
    NVIDIA Network Operator Government Ready <install-network-operator-gov-ready.rst>
    NIC Configuration Operator <nic-conf-operator/nic-configuration-operator.rst>
+   NVIDIA Spectrum-X <spectrum-x/spectrum-x.rst>
    Configuration Assistance with Kubernetes Launch Kit <k8s-launch-kit/k8s-launch-kit.rst>
    AI Skills <ai-skills.rst>
    Customization Options and CRDs <customizations/customization.rst>

--- a/docs/k8s-launch-kit/heterogeneous-clusters.rst
+++ b/docs/k8s-launch-kit/heterogeneous-clusters.rst
@@ -291,18 +291,14 @@ The deployment ordering ensures dependency resolution: NicClusterPolicy first (w
 NIC Interface Name Templates
 ================================================================================
 
-When ``nicConfigurationOperator.deployNicInterfaceNameTemplate`` is set to ``true`` in the configuration, Launch Kit deploys ``NicInterfaceNameTemplate`` CRs to rename NIC interfaces to predictable, rail-based names using udev rules. This setting means "enable when needed" rather than "always enable" --- templates are deployed only when:
-
-- Combined groups have cross-rail PCI address conflicts (the same PCI address appears at different rail positions across source groups). PCI addresses alone cannot identify which interface corresponds to which rail in this case, so the template provides a consistent rail-based mapping.
-- The ``rdma_shared`` profile is used and PFs have empty ``networkInterface`` fields (the shared device plugin needs interface names).
-- Spectrum-X is enabled (always).
+``NicInterfaceNameTemplate`` CRs rename NIC interfaces to predictable, rail-based names using udev rules. Launch Kit deploys them by default for **every** profile and every cluster shape --- not only when PCI addresses are ambiguous. The benefit is uniform interface names across server SKUs (``rdma_r0``, ``eth_r1``, …): pod manifests, NetworkAttachmentDefinitions, and operator scripts can reference one stable name per rail regardless of which vendor chassis the pod lands on, and reboots that re-enumerate PCI no longer break selectors.
 
 Naming conventions:
 
 - Standard profiles: ``rdma_r%rail%``, ``eth_r%rail%`` (e.g., ``rdma_r0``, ``eth_r1``).
 - Spectrum-X profiles: ``roce_p%plane%_r%rail%``, ``eth_p%plane%_r%rail%`` (e.g., ``roce_p0_r2``).
 
-When all machines in a group have identical PCI addresses per rail, name templates are not deployed and PCI addresses identify interfaces directly.
+To opt out and reference interfaces by their original PCI addresses instead, set ``nicConfigurationOperator.deployNicInterfaceNameTemplate: false`` in your ``cluster-config.yaml`` (or ``l8k-config.yaml``). This is rarely needed --- the renamed names are a strict superset of what PCI selectors can express.
 
 ================================================================================
 North-South vs East-West Traffic

--- a/docs/k8s-launch-kit/profiles/spectrum-x.rst
+++ b/docs/k8s-launch-kit/profiles/spectrum-x.rst
@@ -37,7 +37,7 @@ Two reference architectures are supported, selected by Network Operator release:
 - **RA2.2** (current) --- requires ``--network-operator-release 26.4``. Uses ``SpectrumXRailPoolConfig`` (v1alpha2 CRD).
 - **RA2.1** (previous) --- requires ``--network-operator-release 26.1``. Uses ``SriovNetworkPoolConfig`` + ``SriovNetworkNodePolicy`` + ``OVSNetwork`` with NV-IPAM glue.
 
-For deeper Spectrum-X background, see :doc:`Spectrum-X Configuration <../../nic-conf-operator/spectrum-x-configuration>`.
+For deeper Spectrum-X background, see :doc:`Spectrum-X Configuration <../../spectrum-x/spectrum-x-configuration>`.
 
 ================================================================================
 Multiplane Modes
@@ -150,6 +150,6 @@ See Also
 ================================================================================
 
 - :doc:`Deployment Profiles <profiles>` --- decision matrix
-- :doc:`Spectrum-X Configuration <../../nic-conf-operator/spectrum-x-configuration>` --- background and CRD details
+- :doc:`Spectrum-X Configuration <../../spectrum-x/spectrum-x-configuration>` --- background and CRD details
 - :doc:`Generate Workflow <../workflows/generate>` --- generation details
 - :doc:`Configuration Reference <../reference/config>` --- ``spectrumX`` config section

--- a/docs/k8s-launch-kit/reference/cli.rst
+++ b/docs/k8s-launch-kit/reference/cli.rst
@@ -189,7 +189,7 @@ Applies previously generated manifests to the cluster in four phases: NicCluster
 l8k validate
 ================================================================================
 
-Verifies a deployment by running three checks back-to-back: Network Operator Helm release version (compared against ``networkOperator.selectedRelease`` in ``cluster-config.yaml``), per-manifest state classification (READY / IN-PROGRESS / ERROR / MISSING via the per-Kind validator registry), and a data-plane connectivity matrix (apply the example DaemonSet, ping every rail across every pod pair). Writes a self-contained HTML report to ``<deployment-files>/verify-report.html`` by default. Exits 4 on any missing/error manifest, version mismatch, or connectivity-matrix failure. See :doc:`../workflows/validate` for full details.
+Verifies a deployment by running four checks back-to-back: Network Operator Helm release version (compared against ``networkOperator.selectedRelease`` in ``cluster-config.yaml``); per-component version cross-check that walks the live ``NicClusterPolicy`` + ``NicNodePolicy`` and confirms each section's ``.version`` field matches the catalog (catches out-of-band edits and partial upgrades the Helm check misses); per-manifest state classification (READY / IN-PROGRESS / ERROR / MISSING via the per-Kind validator registry); and a data-plane connectivity matrix (apply the example DaemonSet, ping every rail across every pod pair). Writes a self-contained HTML report to ``<deployment-files>/verify-report.html`` by default. Exits 4 on any missing/error manifest, Helm-version mismatch, component-version mismatch, or connectivity-matrix failure. See :doc:`../workflows/validate` for full details.
 
 .. list-table::
    :header-rows: 1

--- a/docs/k8s-launch-kit/reference/cli.rst
+++ b/docs/k8s-launch-kit/reference/cli.rst
@@ -166,7 +166,7 @@ Customization
 l8k deploy
 ================================================================================
 
-Applies previously generated manifests to the cluster in dependency order (NicClusterPolicy first, then per-group NicNodePolicy, then networks and workloads).
+Applies previously generated manifests to the cluster in four phases: NicClusterPolicy first (await ready), per-group NicNodePolicy (await each), all remaining CRs in one batch (controllers reconcile concurrently), then verify every manifest reached a terminal state. Example workload manifests (``*example*``) are skipped here --- they're applied by ``l8k validate --connectivity`` / ``l8k deploy --verify`` as part of the data-plane phase. See :doc:`../workflows/deploy` for the full deployment-ordering description.
 
 .. list-table::
    :header-rows: 1
@@ -178,6 +178,10 @@ Applies previously generated manifests to the cluster in dependency order (NicCl
      - Path to kubeconfig (falls back to ``$KUBECONFIG``).
    * - ``--deployment-files <string>``
      - Directory containing the manifests to apply (default: ``./deployment``).
+   * - ``--deploy-timeout <duration>``
+     - End-to-end wall-clock budget for the apply + reconciliation phase (e.g., ``45m``, ``2h``). ``0`` (default) means no deadline; polls until every manifest reaches a terminal state. Useful for matching a maintenance window when SR-IOV reconciliation on a large cluster can take an hour or more.
+   * - ``--verify``
+     - After a successful apply, chain the connectivity matrix (same flow as ``l8k validate --connectivity``): apply the example DaemonSet, wait for it to roll out, run a ping matrix across every rail and pod pair, then clean up.
    * - ``--dry-run``
      - Preview what would be applied without changing the cluster.
 
@@ -185,7 +189,7 @@ Applies previously generated manifests to the cluster in dependency order (NicCl
 l8k validate
 ================================================================================
 
-Verifies a deployment matches the selected Network Operator release: compares the deployed Helm chart's appVersion with the version expected by ``networkOperator.selectedRelease`` in ``cluster-config.yaml``, then confirms every YAML manifest under ``--deployment-files`` is present in the cluster (skipping example workloads). Exits 4 on any missing manifest or version mismatch. See :doc:`../workflows/validate` for full details.
+Verifies a deployment by running three checks back-to-back: Network Operator Helm release version (compared against ``networkOperator.selectedRelease`` in ``cluster-config.yaml``), per-manifest state classification (READY / IN-PROGRESS / ERROR / MISSING via the per-Kind validator registry), and a data-plane connectivity matrix (apply the example DaemonSet, ping every rail across every pod pair). Writes a self-contained HTML report to ``<deployment-files>/verify-report.html`` by default. Exits 4 on any missing/error manifest, version mismatch, or connectivity-matrix failure. See :doc:`../workflows/validate` for full details.
 
 .. list-table::
    :header-rows: 1
@@ -196,9 +200,21 @@ Verifies a deployment matches the selected Network Operator release: compares th
    * - ``--kubeconfig <string>``
      - Path to kubeconfig (falls back to ``$KUBECONFIG``).
    * - ``--user-config <string>``
-     - Cluster config file (default: ``./cluster-config.yaml``). Read for ``networkOperator.selectedRelease`` and operator namespace.
+     - Cluster config file. Lookup order: explicit path → ``./cluster-config.yaml`` → ``<deployment-files>/../cluster-config.yaml`` → ``<deployment-files>/cluster-config.yaml``. Read for ``networkOperator.selectedRelease`` and operator namespace.
    * - ``--deployment-files <string>``
      - Directory containing the manifests to verify (default: ``./deployment``).
+   * - ``--connectivity``
+     - Run the data-plane ping matrix. Default ``true``. Pass ``--connectivity=false`` to limit validate to the static manifest + Helm-release-version checks.
+   * - ``--connectivity-timeout <duration>``
+     - Wall-clock budget for the connectivity phase (default: ``5m``).
+   * - ``--ping-count <int>``
+     - Number of ICMP echoes per ``src → dst`` pair (``ping -c N``). Default ``3``.
+   * - ``--keep``
+     - Leave the test DaemonSet running after ``--connectivity`` completes (useful for follow-up debugging).
+   * - ``--wait <duration>``
+     - Block validate up to this duration waiting for in-progress manifests to reach a terminal state. ``0`` (default) returns immediately on the first snapshot. Re-polls the cluster every 10 s.
+   * - ``--report-path <string>``
+     - Write the HTML report to this path. Empty (default) writes to ``<deployment-files>/verify-report.html``. Pass ``-`` to skip the report file entirely.
 
 ================================================================================
 l8k preset list

--- a/docs/k8s-launch-kit/workflows/deploy.rst
+++ b/docs/k8s-launch-kit/workflows/deploy.rst
@@ -52,11 +52,26 @@ You can also fold the deploy into the generate step by adding ``--deploy`` to ``
 Deployment Ordering
 ================================================================================
 
-Launch Kit applies manifests in the following order to ensure dependencies are satisfied:
+Launch Kit applies manifests in four phases. The first two block on reconciliation because everything else depends on them; the last two batch the remaining manifests so controllers reconcile concurrently:
 
-#. ``NicClusterPolicy`` (cluster-wide components: Multus, CNI, NV-IPAM, operators). Wait for readiness.
-#. ``NicNodePolicy`` per group (OFED driver, device plugins). Wait for readiness.
-#. Remaining manifests --- network resources (``SriovNetwork``, ``HostDeviceNetwork``, etc.), IP pools, and example workloads.
+#. **NicClusterPolicy** --- applied first, then awaited until the controller reports ``READY``. Per-component ``appliedStates[]`` are surfaced in the progress output ("ready: 7/12; pending: state-OFED, state-multus-cni, …") so an operator sees exactly which component is the laggard.
+#. **NicNodePolicy** --- applied per group, awaited per policy (OFED driver, device plugins land here).
+#. **Remaining manifests** --- every other CR (``SriovNetwork``, ``HostDeviceNetwork``, ``CIDRPool``, ``SpectrumXRailPoolConfig``, …) is applied in a single pass without per-manifest waits, so controllers reconcile concurrently.
+#. **Verify** --- each manifest from phase 3 is polled until it reaches a terminal state. The four-state classification (READY / IN-PROGRESS / ERROR / MISSING) and per-Kind cross-checks (e.g., the SR-IOV silent-failure case where ``syncStatus=Succeeded`` but ``pfNames`` matched zero interfaces) are shared with :doc:`l8k validate <validate>`.
+
+.. note::
+
+   Example workload manifests (filenames matching ``*example*``) are **not** applied by ``l8k deploy``. They are fixtures consumed by the connectivity matrix in ``l8k validate --connectivity`` (or ``l8k deploy --verify``, see below) and are deployed only as part of that ping-matrix phase.
+
+================================================================================
+Deploy-wide Timeout
+================================================================================
+
+``l8k deploy`` has no per-manifest deadline. Pass ``--deploy-timeout <duration>`` to bound the whole apply + reconciliation phase end-to-end (e.g., ``45m``, ``2h``). Without the flag, deploy polls until every manifest reaches a terminal state or the user cancels --- the right default for SR-IOV configuration on large clusters where a single ``SriovNetworkNodePolicy`` reconciliation can outlast any small per-manifest budget.
+
+.. code-block:: bash
+
+   l8k deploy --deploy-timeout 90m
 
 ================================================================================
 Dry-Run Mode
@@ -71,10 +86,22 @@ Preview what would be deployed without making changes:
 Dry-run mode is recommended before any first deployment and before production changes.
 
 ================================================================================
-Verifying the Deployment
+End-to-End Verification (--verify)
 ================================================================================
 
-After deploying, verify that operator pods, OFED driver pods, and example workloads are running:
+Pass ``--verify`` to chain a full data-plane verification right after a successful apply: ``l8k deploy --verify`` applies the manifests, waits for every controller to reconcile, then runs the connectivity ping matrix from :doc:`l8k validate <validate>` (apply the example DaemonSet, wait for every pod to be ``Ready``, ping every rail across every pod pair, clean up).
+
+.. code-block:: bash
+
+   l8k deploy --verify
+
+The matrix's exit code propagates: a failed ping causes ``l8k deploy --verify`` to exit non-zero even though the manifests applied successfully. Combine with ``--keep`` (passed to validate) when debugging.
+
+================================================================================
+Manual Verification
+================================================================================
+
+You can also inspect the deployment manually:
 
 .. code-block:: bash
 

--- a/docs/k8s-launch-kit/workflows/validate.rst
+++ b/docs/k8s-launch-kit/workflows/validate.rst
@@ -28,7 +28,7 @@ Validate Workflow
 
 .. note::
 
-   **Use this when:** you've applied a deployment and want to confirm the cluster matches the configuration that produced it. Three things are reported: Network Operator Helm release version, per-manifest presence in the cluster, and any preset deviations recorded in ``cluster-config.yaml``.
+   **Use this when:** you've applied a deployment and want to confirm both the control plane (operator and CRs reconciled) and the data plane (pods on different nodes can reach each other on every rail). ``l8k validate`` runs three checks back-to-back and emits an HTML report alongside the text/JSON output.
 
 ================================================================================
 Run Validation
@@ -38,7 +38,11 @@ Run Validation
 
    l8k validate
 
-No flags required when defaults apply. ``l8k validate`` reads ``./cluster-config.yaml`` for ``networkOperator.selectedRelease`` and the operator namespace, then checks ``./deployment/`` against the cluster reachable via ``$KUBECONFIG``.
+No flags required when defaults apply. ``l8k validate`` reads ``./cluster-config.yaml`` (or, when not in the working directory, ``<deployment-files>/../cluster-config.yaml``) for ``networkOperator.selectedRelease`` and the operator namespace, then:
+
+#. Classifies every YAML manifest under ``--deployment-files`` against the live cluster.
+#. Runs the connectivity matrix (enabled by default; pass ``--connectivity=false`` to skip).
+#. Writes an HTML validation report to ``<deployment-files>/verify-report.html``.
 
 .. code-block:: bash
 
@@ -61,28 +65,88 @@ The check is **skipped** (with a clear reason in the output) when:
 - The selected release is not in the embedded catalog.
 - No matching Helm release Secret is found in the operator namespace (e.g., the operator was installed via Argo CD or kubectl rather than Helm).
 
-Manifest presence
------------------
+Manifest state
+--------------
 
-Every YAML document under ``--deployment-files`` is fetched from the cluster via the Kubernetes API. Each document is reported:
+Every YAML document under ``--deployment-files`` is routed through a per-Kind validator that classifies it as one of four states:
 
-- ``FOUND`` — the named object exists in the cluster.
-- ``MISSING`` — the named object is not present.
-- ``ERROR`` — the API returned a non-NotFound error (RBAC, transient connectivity, …).
+- ``READY`` — the controller reports the object is fully reconciled. For ``NicClusterPolicy`` and ``NicNodePolicy``, the per-component ``appliedStates[]`` are folded into a "ready: 12/12; components: …" summary so an operator sees exactly what landed.
+- ``IN-PROGRESS`` — the controller is still reconciling. For ``SriovNetworkNodePolicy`` and the ``NicConfigurationTemplate`` / ``NicInterfaceNameTemplate`` Kinds, per-node and per-device breakdowns are surfaced (the SR-IOV silent-failure case where ``syncStatus=Succeeded`` but ``pfNames`` matched zero interfaces is detected and reported as ERROR rather than READY).
+- ``ERROR`` — the controller reported an error state, or a cross-check (expected PFs vs. discovered) failed.
+- ``MISSING`` — the named object is not present in the cluster.
 
-Files matching ``*example*`` (e.g., ``50-example-daemonset.yaml``) are skipped — those are demo workloads, not part of the operator surface.
+Files matching ``*example*`` (e.g., ``50-example-daemonset.yaml``) are skipped here — those are demo workloads consumed by the connectivity matrix, not part of the network-operator surface ``l8k validate`` checks for static state.
+
+Connectivity matrix (default ON)
+--------------------------------
+
+When every manifest is ``READY``, Launch Kit applies the example DaemonSet, waits for it to roll out completely (``numberReady == desiredNumberScheduled > 0`` — a single ``ContainerCreating``-stuck pod fails the wait), enumerates the test pods' rail IPs from each pod's ``k8s.v1.cni.cncf.io/network-status`` annotation, and runs a ping matrix:
+
+- **Same-rail tests** — every ordered ``(srcPod, dstPod)`` pair on every rail both pods attach to. Verifies the rail's end-to-end data path.
+- **Cross-rail canary** — one ping per ordered pod pair from rail-0 → rail-1 (when both pods have ≥2 rails). Catches routing misconfigurations that would otherwise be invisible when every rail passes independently.
+
+The DaemonSet is deleted on exit. Pass ``--keep`` to leave it running for follow-up debugging.
+
+When fewer than two schedulable test pods exist (single-node clusters, pods stuck Pending), the matrix soft-skips with a reason in the report.
 
 Preset deviations
 -----------------
 
-If ``cluster-config.yaml`` records preset deviations (any group has a non-empty ``presetDeviation`` list), they're surfaced under a "Preset deviations" section. Each entry shows the field (``pfCount`` / ``pciAddress`` / ``deviceID``), the expected value, the discovered value, and a short detail. Deviations are reported for visibility — they do **not** affect the exit code, since the deployment can still run correctly while diverging from the matched preset. See :doc:`../presets` "Validation and Deviations".
+If ``cluster-config.yaml`` records preset deviations, they're surfaced under each affected node group in the HTML report's **Node groups** section. Each entry shows the field (``pfCount`` / ``pciAddress`` / ``deviceID``), the expected value, the discovered value, and a short detail. Deviations are reported for visibility — they do **not** affect the exit code, since the deployment can still run correctly while diverging from the matched preset. See :doc:`../presets` "Validation and Deviations".
+
+================================================================================
+HTML Validation Report
+================================================================================
+
+Every ``l8k validate`` run writes a self-contained HTML report to ``<deployment-files>/verify-report.html`` (override with ``--report-path <file>``, disable with ``--report-path=-``). The report is one HTML file with inline CSS — no JavaScript, no external assets — so it can be attached to a ticket, shared in chat, or opened offline.
+
+Report sections:
+
+- **Header** — Launch Kit version, generation timestamp, kubeconfig context, API-server version, operator namespace.
+- **Profile** — fabric, deployment type, multirail, and Spectrum-X (version / multiplane mode / number of planes) when enabled. When ``cluster-config.yaml`` doesn't carry an explicit ``profile:`` block, the profile is inferred from the Kinds present in the rendered deployment manifests.
+- **Node groups** — one card per ``clusterConfig[]`` entry: identifier, machine type, GPU type, link type, node selector, worker-node list, capability pills, and east-west / north-south PF tables (PCI, device ID, rail, netdev, RDMA device, PSID, part number, NUMA node, connected GPU, GPU proximity). Preset deviations are rendered as a sub-table when present.
+- **Cluster nodes** — name, ``nvidia.kubernetes-launch-kit.machine`` and ``.gpu`` labels, role.
+- **Network Operator release** — selected vs. deployed appVersion.
+- **Manifest state** — one row per CR with a state badge and the validator's reason. Two expandable dropdowns per row: **Details** (the SR-IOV per-node breakdown, the NCP appliedStates components, etc.) and **Live YAML** (the cluster's current view of the object, ``managedFields`` stripped, status kept).
+- **Connectivity matrix** — per-rail ``src × dst`` grids with pass/fail/skipped color-coded cells, plus the cross-rail canary list.
+- **Warnings** — bulleted rollup ("connectivity matrix skipped because cluster has in-progress manifests", "SriovNetworkNodePolicy/rail-0 is in-progress on 2/3 nodes", etc.).
+
+================================================================================
+Flag Reference
+================================================================================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - **Flag**
+     - **Description**
+   * - ``--connectivity``
+     - Run the data-plane ping matrix. Default ``true``. Pass ``--connectivity=false`` to limit validate to the static manifest + Helm-release-version checks.
+   * - ``--connectivity-timeout``
+     - Wall-clock budget for the connectivity phase (DaemonSet rollout + ping execs). Default ``5m``.
+   * - ``--ping-count``
+     - Number of ICMP echoes per ``src → dst`` pair (``ping -c N``). Default ``3``.
+   * - ``--keep``
+     - Leave the test DaemonSet running after ``--connectivity`` completes. Useful for follow-up kubectl exec / iperf3 sessions.
+   * - ``--wait``
+     - Block validate up to this duration waiting for in-progress manifests to reach a terminal state. ``0`` (default) returns immediately on the first snapshot. Re-polls the cluster every 10 s.
+   * - ``--report-path``
+     - Write the HTML report to this path. Empty (default) writes to ``<deployment-files>/verify-report.html``. Pass ``-`` to skip the report entirely.
+   * - ``--user-config``
+     - Cluster config file. Lookup order: explicit path → ``./cluster-config.yaml`` → ``<deployment-files>/../cluster-config.yaml`` → ``<deployment-files>/cluster-config.yaml``.
+   * - ``--deployment-files``
+     - Directory containing the manifests to verify (default: ``./deployment``).
+   * - ``--kubeconfig``
+     - Path to kubeconfig (falls back to ``$KUBECONFIG``).
 
 ================================================================================
 Exit Codes
 ================================================================================
 
-- **0** — every manifest is FOUND and the version check matched (or was skipped).
-- **4** — at least one manifest is MISSING or ERROR, or the deployed Helm release version doesn't match the selected release.
+- **0** — every manifest is READY (or all-READY plus IN-PROGRESS without errors) and, when run, the connectivity matrix passed.
+- **0 with warning** — at least one manifest is IN-PROGRESS but none are ERROR / MISSING. Connectivity is skipped because pinging an unready cluster would produce noise. Re-run validate later, or use ``--wait <duration>`` to block.
+- **4** — at least one manifest is MISSING or ERROR, the deployed Helm release version doesn't match the selected release, or the connectivity matrix reported failures.
 - Other codes — see :doc:`../reference/cli` "Exit Codes".
 
 ================================================================================
@@ -93,28 +157,42 @@ Sample Output
 
    Network Operator release
      selectedRelease: 26.4
-     expected version: v26.4.0-beta.6
-     deployed: network-operator (chart=26.4.0-beta.6 app=v26.4.0-beta.6 rev=3 status=deployed)
+     expected version: v26.4.0-beta.9
+     deployed: network-operator (chart=26.4.0-beta.9 app=v26.4.0-beta.9 rev=3 status=deployed)
      result: MATCH
 
    Manifests
-     [FOUND] NicClusterPolicy/nic-cluster-policy in (cluster-scoped)
-     [FOUND] NicNodePolicy/nicnodepolicy-h100 in (cluster-scoped)
-     [MISSING] SriovNetwork/sriov-network-rail-0 in default --- not found in cluster
+     [READY      ] NicClusterPolicy/nic-cluster-policy in (cluster-scoped) — ready — ready: 12/12; components: cni-plugins, ipoib, multus, …
+     [READY      ] NicNodePolicy/nicnodepolicy-h100 in (cluster-scoped) — ready
+     [READY      ] SriovNetworkNodePolicy/ethernet-sriov-rail-0 in network-operator — 2/2 nodes ready
 
-   Preset deviations (cluster differs from matched preset)
-     group-0 (PowerEdge-XE9680/NVIDIA-H200) --- 2 deviation(s):
-       [pciAddress] expected=- got=0000:bd:00.0 --- discovered PCI address not present in preset
-       [deviceID] expected=a2dc@0000:5e:00.0 got=1023@0000:5e:00.0 --- device ID at PCI address differs from preset
+   Summary: 12/12 ready, 0 in-progress, 0 error, 0 missing; version: match; preset deviations: 0 group(s)
 
-   Summary: 12 manifests, 1 missing/error; version: match; preset deviations: 1 group(s)
+   Connectivity matrix
 
-For programmatic use, ``--output json`` emits a single object on stdout with ``versionCheck``, ``manifests``, ``presetDeviations``, and ``summary`` fields. Logs go to stderr.
+   Rail sriov-network-rail-0:
+     src \ dst          c-220-166-240-241  c-220-166-240-242
+     c-220-166-240-241  —                  ✓ 0% 0.1ms
+     c-220-166-240-242  ✓ 0% 0.1ms         —
+
+   Rail sriov-network-rail-1:
+     src \ dst          c-220-166-240-241  c-220-166-240-242
+     c-220-166-240-241  —                  ✓ 0% 0.1ms
+     c-220-166-240-242  ✓ 0% 0.3ms         —
+
+   Cross-rail canary:
+     c-220-166-240-241 [sriov-network-rail-0]  → c-220-166-240-242 [sriov-network-rail-1]  ✓ 0% 0.1ms
+     c-220-166-240-242 [sriov-network-rail-0]  → c-220-166-240-241 [sriov-network-rail-1]  ✓ 0% 0.1ms
+
+   ✓ All 6 ping test(s) passed
+   HTML report written to /home/user/deployment/verify-report.html
+
+For programmatic use, ``--output json`` emits a single object on stdout with ``versionCheck``, ``manifests``, ``presetDeviations``, ``summary``, ``connectivity``, and ``reportPath`` fields. Logs go to stderr.
 
 ==========
 See Also
 ==========
 
-- :doc:`Deploy Workflow <deploy>` --- the writer side of the contract validate checks
-- :doc:`Troubleshooting <../troubleshooting>` --- diagnose missing or failing manifests
+- :doc:`Deploy Workflow <deploy>` --- the writer side of the contract validate checks (also supports ``--verify`` to chain the matrix straight after a successful deploy)
+- :doc:`Troubleshooting <../troubleshooting>` --- diagnose missing or failing manifests and read the HTML report
 - :doc:`CLI Reference <../reference/cli>` --- ``l8k validate`` flag reference

--- a/docs/k8s-launch-kit/workflows/validate.rst
+++ b/docs/k8s-launch-kit/workflows/validate.rst
@@ -28,7 +28,7 @@ Validate Workflow
 
 .. note::
 
-   **Use this when:** you've applied a deployment and want to confirm both the control plane (operator and CRs reconciled) and the data plane (pods on different nodes can reach each other on every rail). ``l8k validate`` runs three checks back-to-back and emits an HTML report alongside the text/JSON output.
+   **Use this when:** you've applied a deployment and want to confirm both the control plane (operator and CRs reconciled, component versions match the requested release) and the data plane (pods on different nodes can reach each other on every rail). ``l8k validate`` runs four checks back-to-back and emits an HTML report alongside the text/JSON output.
 
 ================================================================================
 Run Validation
@@ -64,6 +64,18 @@ The check is **skipped** (with a clear reason in the output) when:
 - ``cluster-config.yaml`` is missing or doesn't declare ``networkOperator.selectedRelease``.
 - The selected release is not in the embedded catalog.
 - No matching Helm release Secret is found in the operator namespace (e.g., the operator was installed via Argo CD or kubectl rather than Helm).
+
+Component versions in NicClusterPolicy and NicNodePolicy
+--------------------------------------------------------
+
+The Helm-release check confirms the *operator* matches the requested release line. Launch Kit also reads the live ``NicClusterPolicy`` and every ``NicNodePolicy`` and verifies that each component's ``.version`` field matches the catalog. This catches drift the Helm check can miss: out-of-band ``kubectl edit`` changes, partial upgrades, hand-rolled chart values that pinned an older image tag.
+
+Sections checked:
+
+- ``NicClusterPolicy`` --- ``nicConfigurationOperator.operator``, ``nicConfigurationOperator.configurationDaemon``, ``nvIpam``, ``secondaryNetwork.cniPlugins``, ``secondaryNetwork.multus``, and ``ofedDriver`` (when the 26.1 model is used).
+- ``NicNodePolicy`` --- ``ofedDriver``, ``rdmaSharedDevicePlugin``, ``sriovDevicePlugin``.
+
+Each row is reported as ``MATCH`` or ``MISMATCH`` with the expected and actual versions side by side. A mismatch fails ``l8k validate`` with exit code 4, the same as a missing manifest or Helm-version mismatch. The check is **skipped** (no impact on exit code) when ``selectedRelease`` is empty, when the catalog doesn't carry that release line, or when the cluster has no ``NicClusterPolicy`` (``l8k deploy`` hasn't been run yet).
 
 Manifest state
 --------------
@@ -106,8 +118,8 @@ Report sections:
 - **Profile** — fabric, deployment type, multirail, and Spectrum-X (version / multiplane mode / number of planes) when enabled. When ``cluster-config.yaml`` doesn't carry an explicit ``profile:`` block, the profile is inferred from the Kinds present in the rendered deployment manifests.
 - **Node groups** — one card per ``clusterConfig[]`` entry: identifier, machine type, GPU type, link type, node selector, worker-node list, capability pills, and east-west / north-south PF tables (PCI, device ID, rail, netdev, RDMA device, PSID, part number, NUMA node, connected GPU, GPU proximity). Preset deviations are rendered as a sub-table when present.
 - **Cluster nodes** — name, ``nvidia.kubernetes-launch-kit.machine`` and ``.gpu`` labels, role.
-- **Network Operator release** — selected vs. deployed appVersion.
-- **Manifest state** — one row per CR with a state badge and the validator's reason. Two expandable dropdowns per row: **Details** (the SR-IOV per-node breakdown, the NCP appliedStates components, etc.) and **Live YAML** (the cluster's current view of the object, ``managedFields`` stripped, status kept).
+- **Network Operator release** — selected vs. deployed appVersion. When the component-version cross-check ran, a sub-table lists every ``NicClusterPolicy`` / ``NicNodePolicy`` section's ``MATCH`` / ``MISMATCH`` against the catalog (expected vs. actual side by side).
+- **Manifest state** — one row per CR with a state badge and the validator's reason. Two expandable rows render full-width directly below each manifest row: **Details** (the SR-IOV per-node breakdown, the NCP appliedStates components, etc.) and **Live YAML** (the cluster's current view of the object, ``managedFields`` stripped, status kept). Manifests with nothing to expand render only the data row.
 - **Connectivity matrix** — per-rail ``src × dst`` grids with pass/fail/skipped color-coded cells, plus the cross-rail canary list.
 - **Warnings** — bulleted rollup ("connectivity matrix skipped because cluster has in-progress manifests", "SriovNetworkNodePolicy/rail-0 is in-progress on 2/3 nodes", etc.).
 

--- a/docs/nic-conf-operator/nic-fw-configuration.rst
+++ b/docs/nic-conf-operator/nic-fw-configuration.rst
@@ -492,4 +492,4 @@ The ``NicInterfaceNameTemplate`` CRD allows you to define custom naming patterns
 
 The operator deploys udev rules to the host to rename network and RDMA interfaces according to the specified naming template. The template uses placeholders (``%nic_id%``, ``%plane_id%``, ``%rail_id%``) to construct device names based on the NIC topology.
 
-For full details on NicInterfaceNameTemplate configuration, including multiplane modes and example udev rules, refer to :doc:`Spectrum-X Configuration <spectrum-x-configuration>`.
+For full details on NicInterfaceNameTemplate configuration, including multiplane modes and example udev rules, refer to :doc:`Spectrum-X Configuration <../spectrum-x/spectrum-x-configuration>`.

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -36,6 +36,13 @@ Changes and New Features
 
    * - Version
      - Description
+   * - 26.4.0
+     - | - Added support for NVIDIA Spectrum-X Reference Architecture 2.2 (RA2.2) with the new ``SpectrumXRailPoolConfig`` v1alpha2 CRD in NVIDIA Spectrum-X Operator
+       | - Added support for ``NicNodePolicy`` CRD, enabling per-node-group DOCA-OFED driver management in NVIDIA Network Operator
+       | - [TECH PREVIEW] Added Dynamic Resource Allocation (DRA) support for SR-IOV in NVIDIA Network Operator
+       | - Added global configuration support for ``NicClusterPolicy``
+       | - Added preflight checks for the DOCA-OFED driver container (kernel module dependency validation prior to driver load)
+       | - Added interactive HTML report output for the SOS report collection script
    * - 26.1.0
      - | Added support for ConnectX-9 SuperNIC
        | - Added support for Spectrum-X Ethernet Networking Platform with Kubernetes [GA]

--- a/docs/spectrum-x/components.rst
+++ b/docs/spectrum-x/components.rst
@@ -1,0 +1,381 @@
+.. license-header
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+.. headings # #, * *, =, -, ^, "
+
+*************************************************
+Spectrum-X Kubernetes Architecture and Components
+*************************************************
+
+A Spectrum-X Kubernetes deployment is a layered stack split across two
+distinct domains:
+
+- **Host Layer** — operating-system prerequisites, firmware settings,
+  kernel drivers, and the host virtual switch. Owned by an automated
+  provisioning stack (or by manual / scripted operator action) and **out
+  of Network Operator scope**.
+- **Kubernetes Layer** — Kubernetes-native operators, CNIs, IPAM, and
+  discovery components. Deployed and reconciled by **NVIDIA Network
+  Operator** on top of a working Kubernetes cluster.
+
+This page maps each component to its role, dependencies, and
+default-enabled state in Network Operator 26.4.0. For exact image versions,
+see the software components table in :doc:`Platform Support
+<../platform-support>`. For end-to-end walkthroughs, see :doc:`Spectrum-X
+Kubernetes Quick Start <quick-start>`.
+
+====================
+Deployment ownership
+====================
+
+Spectrum-X K8s deployments are split across three phases. Host-side
+provisioning (Day 0) is owned outside Network Operator scope; Day 1 and
+Day 2 are reconciled by Network Operator.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 55 30
+
+   * - Phase
+     - Scope
+     - Owner
+   * - **Day 0** (pre-K8s)
+     - Host OS bootstrap, PCIe / SR-IOV firmware, switch fabric, SuperNIC
+       firmware floor, hugepages, RDMA exclusive mode, DOCA-Host /
+       OVS-DOCA install.
+     - Automated provisioning stack or manual / scripted.
+   * - **Day 1** (cluster bring-up)
+     - Driver, operator, and CNI deployment on top of a working Kubernetes
+       cluster; Spectrum-X CRD reconciliation.
+     - NVIDIA Network Operator.
+   * - **Day 2** (workload)
+     - Pod connectivity (secondary networks), rail / plane IP allocation,
+       VF / representor lifecycle.
+     - NVIDIA Network Operator (CNI + IPAM).
+
+==============
+Stack overview
+==============
+
+**Host Layer** *(Day 0 — outside Network Operator scope)*:
+
+- **OS prerequisites** — SR-IOV BIOS + firmware; hugepages; RDMA namespace
+  exclusive mode.
+- **Driver** — DOCA-Host (NVIDIA OFED kernel modules + DOCA tooling).
+- **Virtual switch** — OVS-DOCA (hardware-accelerated Open vSwitch,
+  bundled with DOCA-Host).
+
+**Kubernetes Layer** *(Day 1 / Day 2 — owned by Network Operator)*:
+
+- **Discovery** — Node Feature Discovery (NFD); NIC Feature Discovery.
+- **Driver** *(alternative to host-installed DOCA-Host)* — DOCA-OFED
+  driver container.
+- **Operator** — Network Operator (umbrella); SR-IOV Network Operator;
+  NIC Configuration Operator; Spectrum-X Operator; Maintenance Operator.
+- **CNI / data-plane** — Multus; OVS-CNI; SR-IOV Network Device Plugin;
+  SR-IOV CNI; RDMA-CNI; NV-IPAM; Spectrum-X flow-controller DaemonSet.
+- **Optional / tech preview** — DOCA xPlane (Hardware Multiplane only);
+  SR-IOV DRA driver; NicNodePolicy CRD; DOCA Telemetry Service.
+
+==========
+Host Layer
+==========
+
+The Host Layer is the foundation: operating-system prerequisites, firmware
+settings, kernel drivers, and the host virtual switch that exist on each
+node **before** Kubernetes is installed. These components are typically
+owned by an automated provisioning stack or by manual / scripted operator
+action, and are **not** managed by Network Operator.
+
+OS prerequisites
+----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Component
+     - Role
+   * - **SR-IOV BIOS + firmware**
+       (``SRIOV_EN=True``, ``NUM_OF_VFS=1``)
+     - BIOS and NIC firmware settings that enable Virtual Function
+       creation on each SuperNIC.
+   * - **Hugepages**
+     - Memory backing for OVS-DOCA. 400 MB per SuperNIC from DOCA 3.4
+       onwards (1 GB on earlier DOCA).
+   * - **RDMA namespace exclusive mode**
+       (``options ib_core netns_mode=0``)
+     - Per-namespace RDMA device isolation, required to assign RDMA
+       devices into pod network namespaces.
+
+.. _host-driver:
+
+Driver
+------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Component
+     - Role
+   * - **DOCA-Host**
+     - Host-installed NVIDIA OFED kernel modules and DOCA tooling.
+       Includes OVS-DOCA (see :ref:`host-virtual-switch` below). Default
+       driver path for Spectrum-X RA 2.2 validated deployments.
+
+.. important::
+
+   **DOCA-Host (host-installed)** and the **containerized DOCA-OFED
+   driver** (deployed via Network Operator — see
+   :ref:`k8s-driver-layer`) are **mutually exclusive**. Choose one per
+   node; do not deploy both. Spectrum-X RA 2.2 validated deployments
+   typically use host-installed DOCA-Host.
+
+.. _host-virtual-switch:
+
+Virtual switch
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Component
+     - Role
+   * - **OVS-DOCA**
+     - Hardware-accelerated Open vSwitch, bundled with DOCA-Host. Provides
+       the per-rail OVS bridges into which the Kubernetes Layer's
+       **OVS-CNI** plugs SR-IOV VFs at pod creation time.
+
+================
+Kubernetes Layer
+================
+
+The Kubernetes Layer is what NVIDIA Network Operator deploys and
+reconciles on top of a working Kubernetes cluster. It includes
+Kubernetes-native operators, CNIs, IPAM, and discovery components.
+Configuration is driven through the Spectrum-X CRDs documented in
+:doc:`Spectrum-X CRDs and API Reference <crds>`.
+
+Discovery
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 50 20
+
+   * - Component
+     - Role
+     - Default
+   * - **Node Feature Discovery (NFD)**
+     - Labels nodes with PCI / RDMA / GPU features so SR-IOV Network
+       Operator and the scheduler can target the right hosts.
+     - On by default.
+   * - **NIC Feature Discovery**
+     - NFD extension that exposes NIC-specific capabilities (link type,
+       device IDs) as node labels.
+     - Opt-in.
+
+.. _k8s-driver-layer:
+
+Driver (alternative to host-installed DOCA-Host)
+------------------------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 50 20
+
+   * - Component
+     - Role
+     - Default
+   * - **DOCA-OFED driver container** (``doca-driver``)
+     - Containerized NVIDIA OFED kernel driver. Used **only** when the
+       host does not have DOCA-Host installed. See the host
+       :ref:`Driver <host-driver>` section for the mutual-exclusion rule.
+     - Opt-in via ``ofedDriver`` on ``NicClusterPolicy``.
+
+Operator
+--------
+
+The operator sub-layer is what Network Operator deploys and reconciles
+when you enable the Spectrum-X bits in ``NicClusterPolicy``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 45 18 15
+
+   * - Component
+     - Role
+     - Default
+     - Spectrum-X relevance
+   * - **Network Operator** (umbrella)
+     - Reconciles ``NicClusterPolicy`` (and ``NicNodePolicy``);
+       orchestrates all sub-operators, CNIs, and driver lifecycle.
+     - Always on.
+     - Essential.
+   * - **SR-IOV Network Operator** (sub-chart)
+     - Owns ``SriovNetworkNodePolicy`` and ``OVSNetwork``; manages VF
+       creation, switchdev mode, and ships **OVS-CNI**, **SR-IOV CNI**,
+       **RDMA-CNI**, the SR-IOV Device Plugin, and the DRA driver.
+     - Off by default; **on for Spectrum-X**.
+     - Essential.
+   * - **NIC Configuration Operator**
+     - Owns ``NicConfigurationTemplate``, ``NicFirmwareTemplate``, and
+       ``NicInterfaceNameTemplate``; applies firmware and rail-name
+       templates to each SuperNIC.
+     - Opt-in.
+     - Recommended.
+   * - **Spectrum-X Operator**
+     - Owns ``SpectrumXRailPoolConfig`` and deploys the
+       **flow-controller DaemonSet** that programs per-rail OVS flows on
+       each host (writing into the OVS-DOCA bridges from the Host Layer).
+       Essential for any Spectrum-X mode (single-plane, ``swplb``,
+       ``hwplb``).
+     - Opt-in via ``spectrumXOperator``.
+     - Essential.
+   * - **Maintenance Operator**
+     - Orchestrates node-maintenance windows (drain / cordon) for safe
+       firmware updates and OFED driver upgrades.
+     - Opt-in.
+     - Optional.
+
+CNI / data-plane
+----------------
+
+The CNI / data-plane sub-layer is what actually plugs Virtual Functions
+into pods and routes traffic across rails and planes. Most components are
+deployed by the SR-IOV Network Operator sub-chart but are listed
+individually here because they play distinct roles.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 50 15 10
+
+   * - Component
+     - Role
+     - Default
+     - Spectrum-X relevance
+   * - **Multus CNI**
+     - Meta-CNI that allows pods to attach to multiple networks (one per
+       rail / plane).
+     - Opt-in via ``secondaryNetwork.multus``.
+     - Essential.
+   * - **OVS-CNI**
+     - Plugs SR-IOV VFs into the per-rail OVS bridge (provided by
+       :ref:`OVS-DOCA <host-virtual-switch>` in the Host Layer) and chains
+       with NV-IPAM for address allocation. Shipped under the SR-IOV
+       Network Operator sub-chart.
+     - With SR-IOV Op.
+     - Essential.
+   * - **SR-IOV Network Device Plugin**
+     - Advertises VFs to kubelet as schedulable ``nvidia.com/...``
+       resources.
+     - With SR-IOV Op.
+     - Essential.
+   * - **SR-IOV CNI**
+     - Standard SR-IOV CNI binary. OVS-CNI is the typical Spectrum-X
+       data path; SR-IOV CNI is available for non-OVS deployments.
+     - With SR-IOV Op.
+     - Alternative.
+   * - **RDMA-CNI**
+     - Moves RDMA devices into the pod network namespace (requires RDMA
+       exclusive mode on the host).
+     - With SR-IOV Op.
+     - Optional.
+   * - **NV-IPAM**
+     - Rail / plane-aware IP allocation for pods. Consumes ``CIDRPool``
+       CRDs and assigns IPs to VFs on pod creation.
+     - Opt-in via ``nvIpam``.
+     - Essential.
+   * - **Spectrum-X flow-controller DaemonSet**
+     - Programs OVS flows on each host so packets are forwarded onto the
+       correct rail / plane uplink. Not a separately versioned CNI;
+       deployed by Spectrum-X Operator.
+     - With Spectrum-X Op.
+     - Essential.
+
+Optional / tech preview
+-----------------------
+
+These components are either tech preview in 26.4.0 or strictly optional
+for a Spectrum-X K8s deployment.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 55 20
+
+   * - Component
+     - Role
+     - Status
+   * - **DOCA xPlane** sidecar
+     - DOCA control-plane container used by the Spectrum-X flow controller
+       for **Hardware Multiplane** (``hwplb``) deployments. Not required
+       for single-plane (``none``) or **Software Multiplane** (``swplb``).
+       Deployed via the ``spectrumXOperator.xPlane`` sub-spec on
+       ``NicClusterPolicy``.
+     - **Tech preview** in 26.4.0; planned GA in 26.7.0 alongside
+       ``hwplb`` GA.
+   * - **SR-IOV DRA driver** (``dra-driver-sriov``)
+     - Dynamic Resource Allocation driver for SR-IOV (Kubernetes 1.32+
+       DRA API). Enables fine-grained VF claims via ``ResourceClaim`` and
+       ``ResourceClaimTemplate`` objects.
+     - **Tech preview** in 26.4.0.
+   * - **NicNodePolicy** CRD
+     - Per-node-group DOCA-OFED driver management — supersedes the
+       cluster-wide ``ofedDriver`` setting for heterogeneous clusters.
+     - New in 26.4.0.
+   * - **DOCA Telemetry Service**
+     - Host telemetry exporter for OVS, RDMA, and SuperNIC statistics.
+     - Opt-in.
+
+=========================
+Dependencies and ordering
+=========================
+
+The following dependencies are enforced by Network Operator's
+reconciliation loop and validated by CRD webhooks where applicable:
+
+- **Spectrum-X Operator** requires SR-IOV Network Operator (for OVS-CNI
+  and the SR-IOV Device Plugin), NIC Configuration Operator (for firmware
+  and rail-name templates), NV-IPAM (for rail / plane IP allocation), and
+  Multus (for secondary network attachment). It will not function
+  standalone.
+- **SR-IOV Network Operator** requires NFD labels on nodes and SR-IOV
+  enabled in the host BIOS / firmware (Host Layer). It is off by default
+  in ``NicClusterPolicy`` and must be explicitly enabled for Spectrum-X.
+- **DOCA-OFED driver container** (Kubernetes Layer) and host-installed
+  **DOCA-Host** (Host Layer) are alternatives, not additive. Choose one
+  per node; do not deploy both.
+- **OVS-CNI** (Kubernetes Layer) plugs VFs into OVS bridges provided by
+  **OVS-DOCA** (Host Layer). OVS-DOCA must be present on each node before
+  the Kubernetes Layer can program rail / plane flows.
+- **DOCA xPlane** is required only when ``multiplaneMode: hwplb`` is set
+  on the ``NicConfigurationTemplate``. For single-plane and Software
+  Multiplane deployments, the flow controller runs without xPlane.
+
+===============
+Further reading
+===============
+
+- **Image versions and supported platforms**: see the software components
+  table in :doc:`Platform Support <../platform-support>`.
+- **Spectrum-X CRDs and API reference**: see
+  :doc:`Spectrum-X CRDs and API Reference <crds>`.
+- **NIC firmware and rail-name configuration**: see
+  :doc:`Spectrum-X NIC Configuration <spectrum-x-configuration>`.
+- **End-to-end deployment walkthroughs**: see
+  :doc:`Spectrum-X Kubernetes Quick Start <quick-start>`.

--- a/docs/spectrum-x/crds.rst
+++ b/docs/spectrum-x/crds.rst
@@ -1,5 +1,45 @@
-Spectrum-X Operator API reference v1alpha2
-==========================================
+Spectrum-X CRDs and API Reference
+=================================
+
+A Spectrum-X Kubernetes deployment uses CRDs from several NVIDIA operators
+working together. This page documents the **Spectrum-X Operator** CRDs
+(v1alpha2 — ``SpectrumXRailPoolConfig``). For the other CRDs, see the
+linked references. For the full stack of operators, drivers, and CNIs that
+own these CRDs and how they depend on each other, see
+:doc:`Architecture and Components <components>`.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 22 52
+
+   * - CRD
+     - Owner
+     - Role
+   * - ``NicClusterPolicy``
+     - NVIDIA Network Operator
+     - Cluster-wide operator configuration. Enables NIC Configuration
+       Operator, NV-IPAM, Spectrum-X Operator, and secondary network
+       components.
+   * - ``NicConfigurationTemplate``
+     - NIC Configuration Operator
+     - Per-NIC firmware and Spectrum-X settings (link type, ``numVfs``,
+       multiplane mode, RA version). See
+       :doc:`Spectrum-X NIC Configuration <spectrum-x-configuration>`.
+   * - ``NicInterfaceNameTemplate``
+     - NIC Configuration Operator
+     - Predictable rail / plane-based netdev and RDMA names driven by udev
+       rules.
+   * - ``CIDRPool``
+     - NV-IPAM
+     - Per-rail IP allocation pool consumed by ``SpectrumXRailPoolConfig``.
+   * - :ref:`SpectrumXRailPoolConfig <SpectrumXRailPoolConfig>`
+     - Spectrum-X Operator
+     - Rail topology, PF selection, IPAM binding, and DRA / SR-IOV resource
+       exposure (full API below).
+   * - ``ResourceClaimTemplate``
+     - Kubernetes DRA
+     - Pod-to-GPU+VF binding via Dynamic Resource Allocation (Kubernetes
+       upstream resource).
 
 Packages:
 

--- a/docs/spectrum-x/crds.rst
+++ b/docs/spectrum-x/crds.rst
@@ -1,0 +1,149 @@
+Spectrum-X Operator API reference v1alpha2
+==========================================
+
+Packages:
+
+- :ref:`spectrumx.nvidia.com/v1alpha2 <spectrumx.nvidia.com/v1alpha2>`
+
+.. _spectrumx.nvidia.com/v1alpha2:
+
+spectrumx.nvidia.com/v1alpha2
+-----------------------------
+
+Package v1alpha2 contains API Schema definitions for the spectrumx v1alpha2 API group.
+
+Resource Types:
+
+- :ref:`SpectrumXRailPoolConfig <SpectrumXRailPoolConfig>`
+
+.. _SpectrumXRailPoolConfig:
+
+SpectrumXRailPoolConfig
+~~~~~~~~~~~~~~~~~~~~~~~
+
+SpectrumXRailPoolConfig is the Schema for the spectrumxrailpoolconfigs API.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Field
+     - Description
+   * - ``apiVersion``
+     - ``spectrumx.nvidia.com/v1alpha2``
+   * - ``kind``
+     - ``SpectrumXRailPoolConfig``
+   * - ``metadata``
+     - Standard object metadata. Refer to the Kubernetes API documentation for the fields of the ``metadata`` field.
+   * - | ``spec``
+       | :ref:`SpectrumXRailPoolConfigSpec <SpectrumXRailPoolConfigSpec>`
+     - Desired state of the SpectrumXRailPoolConfig.
+   * - | ``status``
+       | :ref:`SpectrumXRailPoolConfigStatus <SpectrumXRailPoolConfigStatus>`
+     - Observed state of the SpectrumXRailPoolConfig.
+
+.. _SpectrumXRailPoolConfigSpec:
+
+SpectrumXRailPoolConfigSpec
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+(*Appears on:* :ref:`SpectrumXRailPoolConfig <SpectrumXRailPoolConfig>`)
+
+SpectrumXRailPoolConfigSpec defines the desired state of SpectrumXRailPoolConfig.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Field
+     - Description
+   * - | ``draEnabled``
+       | bool
+     - *(Optional)* Enables Dynamic Resource Allocation (DRA) for the configured Spectrum-X nodes. Defaults to ``true``.
+   * - | ``nodeSelector``
+       | map[string]string
+     - *(Optional)* Label selector that identifies the Spectrum-X nodes the configuration applies to.
+   * - | ``maxUnavailable``
+       | `IntOrString <https://godoc.org/k8s.io/apimachinery/pkg/util/intstr#IntOrString>`__
+     - *(Optional)* Either an integer count or a percentage of nodes in the pool that can be configured in parallel. Defaults to ``1``.
+   * - | ``networkNamespace``
+       | string
+     - *(Optional)* Namespace of the NetworkAttachmentDefinition custom resource.
+   * - | ``numVfs``
+       | int
+     - Number of VFs to configure on each PF. Must be ``>= 1``.
+   * - | ``railTopology``
+       | :ref:`[]RailTopology <RailTopology>`
+     - Rails topology list. Must contain at least one entry.
+
+.. _SpectrumXRailPoolConfigStatus:
+
+SpectrumXRailPoolConfigStatus
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+(*Appears on:* :ref:`SpectrumXRailPoolConfig <SpectrumXRailPoolConfig>`)
+
+SpectrumXRailPoolConfigStatus defines the observed state of SpectrumXRailPoolConfig.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Field
+     - Description
+   * - | ``syncStatus``
+       | string
+     - Synchronization status. One of ``Unknown``, ``InProgress``, ``Failed``, ``Succeeded``.
+   * - | ``observedGeneration``
+       | int64
+     - The most recent generation observed by the controller.
+
+.. _RailTopology:
+
+RailTopology
+~~~~~~~~~~~~
+
+(*Appears on:* :ref:`SpectrumXRailPoolConfigSpec <SpectrumXRailPoolConfigSpec>`)
+
+RailTopology describes a single rail in the Spectrum-X pool. Only one of ``cidrPoolRef`` or ``ipam`` may be specified.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Field
+     - Description
+   * - | ``name``
+       | string
+     - Rail topology name. Must be non-empty.
+   * - | ``nicSelector``
+       | :ref:`NicSelector <NicSelector>`
+     - PF selector identifying the NICs that belong to this rail.
+   * - | ``cidrPoolRef``
+       | string
+     - *(Optional)* Reference to a CIDR Pool resource. Mutually exclusive with ``ipam``.
+   * - | ``ipam``
+       | string
+     - *(Optional)* Advanced IPAM configuration. Mutually exclusive with ``cidrPoolRef``.
+   * - | ``mtu``
+       | int
+     - MTU for the rail. Must be ``>= 0``.
+
+.. _NicSelector:
+
+NicSelector
+~~~~~~~~~~~
+
+(*Appears on:* :ref:`RailTopology <RailTopology>`)
+
+NicSelector selects the physical functions that participate in a rail.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Field
+     - Description
+   * - | ``pfNames``
+       | []string
+     - List of PF names. Must contain at least one entry.

--- a/docs/spectrum-x/quick-start-hwplb.rst
+++ b/docs/spectrum-x/quick-start-hwplb.rst
@@ -17,21 +17,36 @@
 .. headings # #, * *, =, -, ^, "
 .. include:: ../common/vars.rst
 
-*********************************
-Spectrum-X Quick Start (hwplb)
-*********************************
+*********************************************************
+Hardware Multiplane Spectrum-X Quick Start (Tech Preview)
+*********************************************************
 
 .. contents:: On this page
    :depth: 3
    :local:
    :backlinks: none
 
+.. warning::
+
+   Hardware Multiplane (``hwplb``) is **tech preview** in Network Operator
+   26.4.0 and is **not part of the validated Spectrum-X Reference
+   Architecture**. Use only for evaluation purposes.
+
 .. note::
 
    You can automate the configuration of this use case with NVIDIA Kubernetes Launch Kit.
    For more details, see :doc:`Configuration Assistance with Kubernetes Launch Kit <../k8s-launch-kit/k8s-launch-kit>`.
 
-The following example uses **RA2.2** with ``hwplb`` multiplane mode. ``hwplb`` is supported only on ConnectX-8 (``nicType: 1023``) and ConnectX-9 (``nicType: 1025``), and only with RA2.2. ``TODO_*`` values must be replaced with cluster-specific values before applying.
+This walkthrough deploys a **Hardware Multiplane** Spectrum-X cluster on
+Kubernetes using **ConnectX-8 SuperNICs** (``nicType: 1023``). NIC LAG and
+**Hardware Plane Load Balancing** (``hwplb``) handle per-plane fan-out at
+the hardware layer, so each rail still uses a single ``CIDRPool`` while
+exposing multiple per-plane PFs. Used on **B300**
+and **GB300** platforms — set ``numberOfPlanes: 2`` for Dual-Plane or
+``numberOfPlanes: 4`` for Quad-Plane (B300 only). The configuration uses
+RA 2.2 with ``multiplaneMode: hwplb``. The example below uses
+``numberOfPlanes: 2``. Replace ``TODO_*`` values with your cluster-specific
+values before applying.
 
 ================================
 Step 1: Install the Helm Chart
@@ -147,7 +162,7 @@ Map PCI addresses to rail/plane indices and define interface naming. Replace ``T
 Step 4: NicConfigurationTemplate
 ==================================
 
-Configure the NICs for Spectrum-X RA2.2 with ``hwplb`` multiplane mode. ``hwplb`` requires ConnectX-8 (``nicType: 1023``) or ConnectX-9 (``nicType: 1025``); it is not supported on BlueField-3 SuperNIC.
+Configure the ConnectX-8 SuperNICs for Spectrum-X RA 2.2 with ``hwplb`` multiplane mode. ``hwplb`` requires ConnectX-8 SuperNIC (``nicType: 1023``); it is not supported on BlueField-3 SuperNIC or ConnectX-7 NIC. For Quad-Plane (B300 only), set ``numberOfPlanes: 4``.
 
 .. code-block:: yaml
 
@@ -160,7 +175,7 @@ Configure the NICs for Spectrum-X RA2.2 with ``hwplb`` multiplane mode. ``hwplb`
      nodeSelector:
        feature.node.kubernetes.io/network-sriov.capable: "true"
      nicSelector:
-       nicType: "1023"  # "1025" for ConnectX-9
+       nicType: "1023"  # ConnectX-8 SuperNIC (B300, GB300)
      template:
        numVfs: 1
        linkType: Ethernet

--- a/docs/spectrum-x/quick-start-hwplb.rst
+++ b/docs/spectrum-x/quick-start-hwplb.rst
@@ -1,0 +1,289 @@
+.. license-header
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+.. headings # #, * *, =, -, ^, "
+.. include:: ../common/vars.rst
+
+*********************************
+Spectrum-X Quick Start (hwplb)
+*********************************
+
+.. contents:: On this page
+   :depth: 3
+   :local:
+   :backlinks: none
+
+.. note::
+
+   You can automate the configuration of this use case with NVIDIA Kubernetes Launch Kit.
+   For more details, see :doc:`Configuration Assistance with Kubernetes Launch Kit <../k8s-launch-kit/k8s-launch-kit>`.
+
+The following example uses **RA2.2** with ``hwplb`` multiplane mode. ``hwplb`` is supported only on ConnectX-8 (``nicType: 1023``) and ConnectX-9 (``nicType: 1025``), and only with RA2.2. ``TODO_*`` values must be replaced with cluster-specific values before applying.
+
+================================
+Step 1: Install the Helm Chart
+================================
+
+Add the NVIDIA NGC Helm repository:
+
+.. code-block:: bash
+
+   helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+   helm repo update
+
+Install the Network Operator. Spectrum-X Operator and NIC Configuration Operator are deployed via the same chart and enabled later through ``NicClusterPolicy``.
+
+.. code-block:: bash
+   :substitutions:
+
+   helm install network-operator nvidia/network-operator \
+     -n nvidia-network-operator \
+     --create-namespace \
+     --version |helm-chart-version| \
+     --set sriovNetworkOperator.enabled=true \
+     --wait
+
+Verify the installation:
+
+.. code-block:: bash
+
+   kubectl -n nvidia-network-operator get pods
+
+================================
+Step 2: Apply NicClusterPolicy
+================================
+
+Enable the NIC Configuration Operator, NV-IPAM, Spectrum-X Operator (with XPlane), and the secondary network components.
+
+.. code-block:: yaml
+   :substitutions:
+
+   apiVersion: mellanox.com/v1alpha1
+   kind: NicClusterPolicy
+   metadata:
+     name: nic-cluster-policy
+   spec:
+     nicConfigurationOperator:
+       operator:
+         image: nic-configuration-operator
+         repository: |network-operator-repository|
+         version: |nic-configuration-operator-version|
+       configurationDaemon:
+         image: nic-configuration-operator-daemon
+         repository: |network-operator-repository|
+         version: |nic-configuration-operator-version|
+       nicFirmwareStorage:
+         create: true
+         pvcName: nic-fw-storage-pvc
+         storageClassName: nic-fw-storage-class
+         availableStorageSize: 1Gi
+       logLevel: info
+     nvIpam:
+       image: nvidia-k8s-ipam
+       repository: |network-operator-repository|
+       version: |nvidia-ipam-version|
+       enableWebhook: false
+     spectrumXOperator:
+       image: spectrum-x-operator
+       repository: |network-operator-repository|
+       version: |spectrumxop-version|
+       xPlane:
+         image: xplane
+         repository: |network-operator-repository|
+         version: |spectrumxop-version|
+     secondaryNetwork:
+       cniPlugins:
+         image: plugins
+         repository: |network-operator-repository|
+         version: |cni-plugins-version|
+       multus:
+         image: multus-cni
+         repository: |network-operator-repository|
+         version: |multus-version|
+
+.. code-block:: bash
+
+   kubectl apply -f nicclusterpolicy.yaml
+
+==================================
+Step 3: NicInterfaceNameTemplate
+==================================
+
+Map PCI addresses to rail/plane indices and define interface naming. Replace ``TODO_PCI_*`` with the PCI addresses of the Spectrum-X NICs on your nodes.
+
+.. code-block:: yaml
+
+   apiVersion: configuration.net.nvidia.com/v1alpha1
+   kind: NicInterfaceNameTemplate
+   metadata:
+     name: spectrum-x-interface-names
+     namespace: nvidia-network-operator
+   spec:
+     pfsPerNic: 2
+     rdmaDevicePrefix: "rdma_rail%rail_id%_plane%plane_id%"
+     netDevicePrefix: "net_rail%rail_id%_plane%plane_id%"
+     railPciAddresses:
+       - ["TODO_PCI_RAIL0_NIC0", "TODO_PCI_RAIL0_NIC1"]
+       - ["TODO_PCI_RAIL1_NIC0", "TODO_PCI_RAIL1_NIC1"]
+
+.. code-block:: bash
+
+   kubectl apply -f nicinterfacenametemplate.yaml
+
+==================================
+Step 4: NicConfigurationTemplate
+==================================
+
+Configure the NICs for Spectrum-X RA2.2 with ``hwplb`` multiplane mode. ``hwplb`` requires ConnectX-8 (``nicType: 1023``) or ConnectX-9 (``nicType: 1025``); it is not supported on BlueField-3 SuperNIC.
+
+.. code-block:: yaml
+
+   apiVersion: configuration.net.nvidia.com/v1alpha1
+   kind: NicConfigurationTemplate
+   metadata:
+     name: spectrum-x-configuration
+     namespace: nvidia-network-operator
+   spec:
+     nodeSelector:
+       feature.node.kubernetes.io/network-sriov.capable: "true"
+     nicSelector:
+       nicType: "1023"  # "1025" for ConnectX-9
+     template:
+       numVfs: 1
+       linkType: Ethernet
+       spectrumXOptimized:
+         enabled: true
+         version: "RA2.2"
+         overlay: "none"
+         multiplaneMode: "hwplb"
+         numberOfPlanes: 2
+
+.. code-block:: bash
+
+   kubectl apply -f nicconfigurationtemplate.yaml
+
+================================
+Step 5: CIDRPool (per rail)
+================================
+
+With ``hwplb``, load balancing happens at the NIC layer, so each rail uses a single ``CIDRPool`` covering all of its planes. Replace ``TODO_*`` with subnets that match your cluster's east-west topology.
+
+.. code-block:: yaml
+
+   apiVersion: nv-ipam.nvidia.com/v1alpha1
+   kind: CIDRPool
+   metadata:
+     name: rail-0
+     namespace: nvidia-network-operator
+   spec:
+     cidr: TODO_RAIL0_CIDR             # e.g., 10.0.0.0/15
+     gatewayIndex: 0
+     perNodeNetworkPrefix: 31
+     perNodeExclusions:
+       - startIndex: 1
+         endIndex: 1
+     routes:
+       - dst: TODO_RAIL0_SUBNET        # same as cidr
+       - dst: TODO_EAST_WEST_SUBNET
+   ---
+   apiVersion: nv-ipam.nvidia.com/v1alpha1
+   kind: CIDRPool
+   metadata:
+     name: rail-1
+     namespace: nvidia-network-operator
+   spec:
+     cidr: TODO_RAIL1_CIDR
+     gatewayIndex: 0
+     perNodeNetworkPrefix: 31
+     perNodeExclusions:
+       - startIndex: 1
+         endIndex: 1
+     routes:
+       - dst: TODO_RAIL1_SUBNET
+       - dst: TODO_EAST_WEST_SUBNET
+
+.. code-block:: bash
+
+   kubectl apply -f cidrpool.yaml
+
+================================
+Step 6: SpectrumXRailPoolConfig
+================================
+
+With ``hwplb``, ``railTopology`` has one entry per rail. Each entry lists all per-plane PF netdev names belonging to that rail and references a single per-rail ``CIDRPool``.
+
+.. code-block:: yaml
+
+   apiVersion: spectrumx.nvidia.com/v1alpha2
+   kind: SpectrumXRailPoolConfig
+   metadata:
+     name: rails
+     namespace: nvidia-network-operator
+   spec:
+     draEnabled: true
+     networkNamespace: default
+     numVfs: 1
+     railTopology:
+       - name: rail0
+         nicSelector:
+           pfNames: ["net_rail0_plane0", "net_rail0_plane1"]
+         cidrPoolRef: rail-0
+         mtu: 9216
+       - name: rail1
+         nicSelector:
+           pfNames: ["net_rail1_plane0", "net_rail1_plane1"]
+         cidrPoolRef: rail-1
+         mtu: 9216
+
+.. code-block:: bash
+
+   kubectl apply -f spectrumxrailpoolconfig.yaml
+
+================================
+Step 7: Deploy a Test Pod
+================================
+
+Request one VF per rail. The network annotation references the rails created by ``SpectrumXRailPoolConfig``.
+
+.. code-block:: yaml
+
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: spectrum-x-test
+     namespace: default
+     annotations:
+       k8s.v1.cni.cncf.io/networks: rail0,rail1
+   spec:
+     containers:
+       - name: spectrum-x-test
+         image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+         command: ["/bin/bash", "-c", "sleep infinity"]
+         securityContext:
+           capabilities:
+             add: ["IPC_LOCK", "NET_RAW"]
+         resources:
+           requests:
+             nvidia.com/rail_0: "1"
+             nvidia.com/rail_1: "1"
+           limits:
+             nvidia.com/rail_0: "1"
+             nvidia.com/rail_1: "1"
+
+.. code-block:: bash
+
+   kubectl apply -f pod.yaml
+   kubectl -n default exec -it spectrum-x-test -- rdma link

--- a/docs/spectrum-x/quick-start-single-plane.rst
+++ b/docs/spectrum-x/quick-start-single-plane.rst
@@ -17,9 +17,9 @@
 .. headings # #, * *, =, -, ^, "
 .. include:: ../common/vars.rst
 
-***************************************************
-Spectrum-X Quick Start (single plane, BF3 SuperNIC)
-***************************************************
+***********************************
+Single-Plane Spectrum-X Quick Start
+***********************************
 
 .. contents:: On this page
    :depth: 3
@@ -31,7 +31,16 @@ Spectrum-X Quick Start (single plane, BF3 SuperNIC)
    You can automate the configuration of this use case with NVIDIA Kubernetes Launch Kit.
    For more details, see :doc:`Configuration Assistance with Kubernetes Launch Kit <../k8s-launch-kit/k8s-launch-kit>`.
 
-The following example uses **RA2.2** with single-plane configuration (``multiplaneMode: none``, ``numberOfPlanes: 1``) on **BlueField-3 SuperNIC** (``nicType: a2dc``). The same single-plane configuration also works on ConnectX-8 and ConnectX-9 — change ``nicType`` accordingly. ``TODO_*`` values must be replaced with cluster-specific values before applying.
+This walkthrough deploys a **Single-Plane** Spectrum-X cluster on Kubernetes:
+one PF per rail, one ``CIDRPool`` per rail, one network per rail. Used on
+**HGX H100/H200/B200** platforms (BlueField-3 SuperNIC, ``nicType: a2dc``) and
+**GB200 NVL72** platforms (ConnectX-7 NIC, ``nicType: 1021``).
+**ConnectX-8 SuperNIC** (``nicType: 1023``) also supports single-plane configuration —
+useful if you want a single-plane setup on B300/GB300 hardware. The
+configuration uses RA 2.2 with ``multiplaneMode: none`` and
+``numberOfPlanes: 1``. The example below uses BlueField-3 SuperNIC; change
+``nicType`` for other NICs. Replace ``TODO_*`` values with your
+cluster-specific values before applying.
 
 ================================
 Step 1: Install the Helm Chart
@@ -100,6 +109,8 @@ Enable the NIC Configuration Operator, NV-IPAM, Spectrum-X Operator (with XPlane
        image: spectrum-x-operator
        repository: |network-operator-repository|
        version: |spectrumxop-version|
+       # xPlane is only used when multiplaneMode=hwplb (Hardware Multiplane).
+       # Including it here lets you flip multiplaneMode without re-applying NicClusterPolicy.
        xPlane:
          image: xplane
          repository: |network-operator-repository|
@@ -122,7 +133,7 @@ Enable the NIC Configuration Operator, NV-IPAM, Spectrum-X Operator (with XPlane
 Step 3: NicInterfaceNameTemplate
 ==================================
 
-Map PCI addresses to rails and define interface naming. With single-plane configuration there is one PF per NIC, so ``pfsPerNic`` is ``1`` and ``%plane_id%`` is always ``0``. Replace ``TODO_PCI_*`` with the PCI addresses of the BF3 SuperNICs on your nodes.
+Map PCI addresses to rails and define interface naming. With single-plane configuration there is one PF per NIC, so ``pfsPerNic`` is ``1`` and ``%plane_id%`` is always ``0``. Replace ``TODO_PCI_*`` with the PCI addresses of the BlueField-3 SuperNICs on your nodes.
 
 .. code-block:: yaml
 
@@ -147,7 +158,7 @@ Map PCI addresses to rails and define interface naming. With single-plane config
 Step 4: NicConfigurationTemplate
 ==================================
 
-Configure the BF3 SuperNICs for Spectrum-X RA2.2 in single-plane mode.
+Configure the NICs for Spectrum-X RA 2.2 in single-plane mode. Use ``nicType: a2dc`` for BlueField-3 SuperNIC (HGX H100/H200/B200), ``nicType: 1021`` for ConnectX-7 NIC (GB200), or ``nicType: 1023`` for ConnectX-8 SuperNIC.
 
 .. code-block:: yaml
 
@@ -160,7 +171,7 @@ Configure the BF3 SuperNICs for Spectrum-X RA2.2 in single-plane mode.
      nodeSelector:
        feature.node.kubernetes.io/network-sriov.capable: "true"
      nicSelector:
-       nicType: "a2dc"  # BlueField-3 SuperNIC. "1023" for ConnectX-8; "1025" for ConnectX-9.
+       nicType: "a2dc"  # BlueField-3 SuperNIC (HGX H100/H200/B200). Use "1021" for ConnectX-7 NIC (GB200) or "1023" for ConnectX-8 SuperNIC.
      template:
        numVfs: 1
        linkType: Ethernet

--- a/docs/spectrum-x/quick-start-single-plane.rst
+++ b/docs/spectrum-x/quick-start-single-plane.rst
@@ -1,0 +1,289 @@
+.. license-header
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+.. headings # #, * *, =, -, ^, "
+.. include:: ../common/vars.rst
+
+***************************************************
+Spectrum-X Quick Start (single plane, BF3 SuperNIC)
+***************************************************
+
+.. contents:: On this page
+   :depth: 3
+   :local:
+   :backlinks: none
+
+.. note::
+
+   You can automate the configuration of this use case with NVIDIA Kubernetes Launch Kit.
+   For more details, see :doc:`Configuration Assistance with Kubernetes Launch Kit <../k8s-launch-kit/k8s-launch-kit>`.
+
+The following example uses **RA2.2** with single-plane configuration (``multiplaneMode: none``, ``numberOfPlanes: 1``) on **BlueField-3 SuperNIC** (``nicType: a2dc``). The same single-plane configuration also works on ConnectX-8 and ConnectX-9 — change ``nicType`` accordingly. ``TODO_*`` values must be replaced with cluster-specific values before applying.
+
+================================
+Step 1: Install the Helm Chart
+================================
+
+Add the NVIDIA NGC Helm repository:
+
+.. code-block:: bash
+
+   helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+   helm repo update
+
+Install the Network Operator. Spectrum-X Operator and NIC Configuration Operator are deployed via the same chart and enabled later through ``NicClusterPolicy``.
+
+.. code-block:: bash
+   :substitutions:
+
+   helm install network-operator nvidia/network-operator \
+     -n nvidia-network-operator \
+     --create-namespace \
+     --version |helm-chart-version| \
+     --set sriovNetworkOperator.enabled=true \
+     --wait
+
+Verify the installation:
+
+.. code-block:: bash
+
+   kubectl -n nvidia-network-operator get pods
+
+================================
+Step 2: Apply NicClusterPolicy
+================================
+
+Enable the NIC Configuration Operator, NV-IPAM, Spectrum-X Operator (with XPlane), and the secondary network components.
+
+.. code-block:: yaml
+   :substitutions:
+
+   apiVersion: mellanox.com/v1alpha1
+   kind: NicClusterPolicy
+   metadata:
+     name: nic-cluster-policy
+   spec:
+     nicConfigurationOperator:
+       operator:
+         image: nic-configuration-operator
+         repository: |network-operator-repository|
+         version: |nic-configuration-operator-version|
+       configurationDaemon:
+         image: nic-configuration-operator-daemon
+         repository: |network-operator-repository|
+         version: |nic-configuration-operator-version|
+       nicFirmwareStorage:
+         create: true
+         pvcName: nic-fw-storage-pvc
+         storageClassName: nic-fw-storage-class
+         availableStorageSize: 1Gi
+       logLevel: info
+     nvIpam:
+       image: nvidia-k8s-ipam
+       repository: |network-operator-repository|
+       version: |nvidia-ipam-version|
+       enableWebhook: false
+     spectrumXOperator:
+       image: spectrum-x-operator
+       repository: |network-operator-repository|
+       version: |spectrumxop-version|
+       xPlane:
+         image: xplane
+         repository: |network-operator-repository|
+         version: |spectrumxop-version|
+     secondaryNetwork:
+       cniPlugins:
+         image: plugins
+         repository: |network-operator-repository|
+         version: |cni-plugins-version|
+       multus:
+         image: multus-cni
+         repository: |network-operator-repository|
+         version: |multus-version|
+
+.. code-block:: bash
+
+   kubectl apply -f nicclusterpolicy.yaml
+
+==================================
+Step 3: NicInterfaceNameTemplate
+==================================
+
+Map PCI addresses to rails and define interface naming. With single-plane configuration there is one PF per NIC, so ``pfsPerNic`` is ``1`` and ``%plane_id%`` is always ``0``. Replace ``TODO_PCI_*`` with the PCI addresses of the BF3 SuperNICs on your nodes.
+
+.. code-block:: yaml
+
+   apiVersion: configuration.net.nvidia.com/v1alpha1
+   kind: NicInterfaceNameTemplate
+   metadata:
+     name: spectrum-x-interface-names
+     namespace: nvidia-network-operator
+   spec:
+     pfsPerNic: 1
+     rdmaDevicePrefix: "rdma_rail%rail_id%"
+     netDevicePrefix: "net_rail%rail_id%"
+     railPciAddresses:
+       - ["TODO_PCI_RAIL0_NIC0"]
+       - ["TODO_PCI_RAIL1_NIC0"]
+
+.. code-block:: bash
+
+   kubectl apply -f nicinterfacenametemplate.yaml
+
+==================================
+Step 4: NicConfigurationTemplate
+==================================
+
+Configure the BF3 SuperNICs for Spectrum-X RA2.2 in single-plane mode.
+
+.. code-block:: yaml
+
+   apiVersion: configuration.net.nvidia.com/v1alpha1
+   kind: NicConfigurationTemplate
+   metadata:
+     name: spectrum-x-configuration
+     namespace: nvidia-network-operator
+   spec:
+     nodeSelector:
+       feature.node.kubernetes.io/network-sriov.capable: "true"
+     nicSelector:
+       nicType: "a2dc"  # BlueField-3 SuperNIC. "1023" for ConnectX-8; "1025" for ConnectX-9.
+     template:
+       numVfs: 1
+       linkType: Ethernet
+       spectrumXOptimized:
+         enabled: true
+         version: "RA2.2"
+         overlay: "none"
+         multiplaneMode: "none"
+         numberOfPlanes: 1
+
+.. code-block:: bash
+
+   kubectl apply -f nicconfigurationtemplate.yaml
+
+================================
+Step 5: CIDRPool (per rail)
+================================
+
+In single-plane mode each rail is a single network, so one ``CIDRPool`` per rail is sufficient. Replace ``TODO_*`` with subnets that match your cluster's east-west topology.
+
+.. code-block:: yaml
+
+   apiVersion: nv-ipam.nvidia.com/v1alpha1
+   kind: CIDRPool
+   metadata:
+     name: rail-0
+     namespace: nvidia-network-operator
+   spec:
+     cidr: TODO_RAIL0_CIDR             # e.g., 10.0.0.0/15
+     gatewayIndex: 0
+     perNodeNetworkPrefix: 31
+     perNodeExclusions:
+       - startIndex: 1
+         endIndex: 1
+     routes:
+       - dst: TODO_RAIL0_SUBNET        # same as cidr
+       - dst: TODO_EAST_WEST_SUBNET
+   ---
+   apiVersion: nv-ipam.nvidia.com/v1alpha1
+   kind: CIDRPool
+   metadata:
+     name: rail-1
+     namespace: nvidia-network-operator
+   spec:
+     cidr: TODO_RAIL1_CIDR
+     gatewayIndex: 0
+     perNodeNetworkPrefix: 31
+     perNodeExclusions:
+       - startIndex: 1
+         endIndex: 1
+     routes:
+       - dst: TODO_RAIL1_SUBNET
+       - dst: TODO_EAST_WEST_SUBNET
+
+.. code-block:: bash
+
+   kubectl apply -f cidrpool.yaml
+
+================================
+Step 6: SpectrumXRailPoolConfig
+================================
+
+One entry in ``railTopology`` per rail, selecting the single PF in that rail (matching ``NicInterfaceNameTemplate``) and referencing the matching ``CIDRPool``.
+
+.. code-block:: yaml
+
+   apiVersion: spectrumx.nvidia.com/v1alpha2
+   kind: SpectrumXRailPoolConfig
+   metadata:
+     name: rails
+     namespace: nvidia-network-operator
+   spec:
+     draEnabled: true
+     networkNamespace: default
+     numVfs: 1
+     railTopology:
+       - name: rail0
+         nicSelector:
+           pfNames: ["net_rail0"]
+         cidrPoolRef: rail-0
+         mtu: 9216
+       - name: rail1
+         nicSelector:
+           pfNames: ["net_rail1"]
+         cidrPoolRef: rail-1
+         mtu: 9216
+
+.. code-block:: bash
+
+   kubectl apply -f spectrumxrailpoolconfig.yaml
+
+================================
+Step 7: Deploy a Test Pod
+================================
+
+Request one VF per rail. The network annotation references the rails created by ``SpectrumXRailPoolConfig``.
+
+.. code-block:: yaml
+
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: spectrum-x-test
+     namespace: default
+     annotations:
+       k8s.v1.cni.cncf.io/networks: rail0,rail1
+   spec:
+     containers:
+       - name: spectrum-x-test
+         image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+         command: ["/bin/bash", "-c", "sleep infinity"]
+         securityContext:
+           capabilities:
+             add: ["IPC_LOCK", "NET_RAW"]
+         resources:
+           requests:
+             nvidia.com/rail_0: "1"
+             nvidia.com/rail_1: "1"
+           limits:
+             nvidia.com/rail_0: "1"
+             nvidia.com/rail_1: "1"
+
+.. code-block:: bash
+
+   kubectl apply -f pod.yaml
+   kubectl -n default exec -it spectrum-x-test -- rdma link

--- a/docs/spectrum-x/quick-start-swplb.rst
+++ b/docs/spectrum-x/quick-start-swplb.rst
@@ -17,9 +17,9 @@
 .. headings # #, * *, =, -, ^, "
 .. include:: ../common/vars.rst
 
-*********************************
-Spectrum-X Quick Start (swplb)
-*********************************
+******************************************
+Software Multiplane Spectrum-X Quick Start
+******************************************
 
 .. contents:: On this page
    :depth: 3
@@ -31,7 +31,15 @@ Spectrum-X Quick Start (swplb)
    You can automate the configuration of this use case with NVIDIA Kubernetes Launch Kit.
    For more details, see :doc:`Configuration Assistance with Kubernetes Launch Kit <../k8s-launch-kit/k8s-launch-kit>`.
 
-The following example uses **RA2.2** with ``swplb`` multiplane mode. ``swplb`` is supported on ConnectX-8, ConnectX-9, and BlueField-3 SuperNIC. ``TODO_*`` values must be replaced with cluster-specific values before applying.
+This walkthrough deploys a **Software Multiplane** Spectrum-X cluster on
+Kubernetes using **ConnectX-8 SuperNICs** (``nicType: 1023``). Each SuperNIC
+is split into multiple PFs, each assigned to a separate plane, and the
+software stack performs **Software Plane Load Balancing** (``swplb``) across
+them. Used on **B300** and **GB300** platforms — set ``numberOfPlanes: 2``
+for Dual-Plane or ``numberOfPlanes: 4`` for Quad-Plane (B300 only). The
+configuration uses RA 2.2 with ``multiplaneMode: swplb``. The example below
+uses ``numberOfPlanes: 2``. Replace ``TODO_*`` values with your
+cluster-specific values before applying.
 
 ================================
 Step 1: Install the Helm Chart
@@ -100,6 +108,8 @@ Enable the NIC Configuration Operator, NV-IPAM, Spectrum-X Operator (with XPlane
        image: spectrum-x-operator
        repository: |network-operator-repository|
        version: |spectrumxop-version|
+       # xPlane is only used when multiplaneMode=hwplb (Hardware Multiplane).
+       # Including it here lets you flip multiplaneMode without re-applying NicClusterPolicy.
        xPlane:
          image: xplane
          repository: |network-operator-repository|
@@ -147,7 +157,7 @@ Map PCI addresses to rail/plane indices and define interface naming. Replace ``T
 Step 4: NicConfigurationTemplate
 ==================================
 
-Configure the NICs for Spectrum-X RA2.2 with ``swplb`` multiplane mode. ``swplb`` is supported on ConnectX-8 (``nicType: 1023``), ConnectX-9 (``nicType: 1025``), and BlueField-3 SuperNIC (``nicType: a2dc``).
+Configure the ConnectX-8 SuperNICs for Spectrum-X RA 2.2 with ``swplb`` multiplane mode. For Quad-Plane (B300 only), set ``numberOfPlanes: 4``.
 
 .. code-block:: yaml
 
@@ -160,7 +170,7 @@ Configure the NICs for Spectrum-X RA2.2 with ``swplb`` multiplane mode. ``swplb`
      nodeSelector:
        feature.node.kubernetes.io/network-sriov.capable: "true"
      nicSelector:
-       nicType: "1023"  # "1025" for ConnectX-9; "a2dc" for BlueField-3 SuperNIC
+       nicType: "1023"  # ConnectX-8 SuperNIC (B300, GB300)
      template:
        numVfs: 1
        linkType: Ethernet

--- a/docs/spectrum-x/quick-start-swplb.rst
+++ b/docs/spectrum-x/quick-start-swplb.rst
@@ -1,0 +1,335 @@
+.. license-header
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+.. headings # #, * *, =, -, ^, "
+.. include:: ../common/vars.rst
+
+*********************************
+Spectrum-X Quick Start (swplb)
+*********************************
+
+.. contents:: On this page
+   :depth: 3
+   :local:
+   :backlinks: none
+
+.. note::
+
+   You can automate the configuration of this use case with NVIDIA Kubernetes Launch Kit.
+   For more details, see :doc:`Configuration Assistance with Kubernetes Launch Kit <../k8s-launch-kit/k8s-launch-kit>`.
+
+The following example uses **RA2.2** with ``swplb`` multiplane mode. ``swplb`` is supported on ConnectX-8, ConnectX-9, and BlueField-3 SuperNIC. ``TODO_*`` values must be replaced with cluster-specific values before applying.
+
+================================
+Step 1: Install the Helm Chart
+================================
+
+Add the NVIDIA NGC Helm repository:
+
+.. code-block:: bash
+
+   helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+   helm repo update
+
+Install the Network Operator. Spectrum-X Operator and NIC Configuration Operator are deployed via the same chart and enabled later through ``NicClusterPolicy``.
+
+.. code-block:: bash
+   :substitutions:
+
+   helm install network-operator nvidia/network-operator \
+     -n nvidia-network-operator \
+     --create-namespace \
+     --version |helm-chart-version| \
+     --set sriovNetworkOperator.enabled=true \
+     --wait
+
+Verify the installation:
+
+.. code-block:: bash
+
+   kubectl -n nvidia-network-operator get pods
+
+================================
+Step 2: Apply NicClusterPolicy
+================================
+
+Enable the NIC Configuration Operator, NV-IPAM, Spectrum-X Operator (with XPlane), and the secondary network components.
+
+.. code-block:: yaml
+   :substitutions:
+
+   apiVersion: mellanox.com/v1alpha1
+   kind: NicClusterPolicy
+   metadata:
+     name: nic-cluster-policy
+   spec:
+     nicConfigurationOperator:
+       operator:
+         image: nic-configuration-operator
+         repository: |network-operator-repository|
+         version: |nic-configuration-operator-version|
+       configurationDaemon:
+         image: nic-configuration-operator-daemon
+         repository: |network-operator-repository|
+         version: |nic-configuration-operator-version|
+       nicFirmwareStorage:
+         create: true
+         pvcName: nic-fw-storage-pvc
+         storageClassName: nic-fw-storage-class
+         availableStorageSize: 1Gi
+       logLevel: info
+     nvIpam:
+       image: nvidia-k8s-ipam
+       repository: |network-operator-repository|
+       version: |nvidia-ipam-version|
+       enableWebhook: false
+     spectrumXOperator:
+       image: spectrum-x-operator
+       repository: |network-operator-repository|
+       version: |spectrumxop-version|
+       xPlane:
+         image: xplane
+         repository: |network-operator-repository|
+         version: |spectrumxop-version|
+     secondaryNetwork:
+       cniPlugins:
+         image: plugins
+         repository: |network-operator-repository|
+         version: |cni-plugins-version|
+       multus:
+         image: multus-cni
+         repository: |network-operator-repository|
+         version: |multus-version|
+
+.. code-block:: bash
+
+   kubectl apply -f nicclusterpolicy.yaml
+
+==================================
+Step 3: NicInterfaceNameTemplate
+==================================
+
+Map PCI addresses to rail/plane indices and define interface naming. Replace ``TODO_PCI_*`` with the PCI addresses of the Spectrum-X NICs on your nodes.
+
+.. code-block:: yaml
+
+   apiVersion: configuration.net.nvidia.com/v1alpha1
+   kind: NicInterfaceNameTemplate
+   metadata:
+     name: spectrum-x-interface-names
+     namespace: nvidia-network-operator
+   spec:
+     pfsPerNic: 2
+     rdmaDevicePrefix: "rdma_rail%rail_id%_plane%plane_id%"
+     netDevicePrefix: "net_rail%rail_id%_plane%plane_id%"
+     railPciAddresses:
+       - ["TODO_PCI_RAIL0_NIC0", "TODO_PCI_RAIL0_NIC1"]
+       - ["TODO_PCI_RAIL1_NIC0", "TODO_PCI_RAIL1_NIC1"]
+
+.. code-block:: bash
+
+   kubectl apply -f nicinterfacenametemplate.yaml
+
+==================================
+Step 4: NicConfigurationTemplate
+==================================
+
+Configure the NICs for Spectrum-X RA2.2 with ``swplb`` multiplane mode. ``swplb`` is supported on ConnectX-8 (``nicType: 1023``), ConnectX-9 (``nicType: 1025``), and BlueField-3 SuperNIC (``nicType: a2dc``).
+
+.. code-block:: yaml
+
+   apiVersion: configuration.net.nvidia.com/v1alpha1
+   kind: NicConfigurationTemplate
+   metadata:
+     name: spectrum-x-configuration
+     namespace: nvidia-network-operator
+   spec:
+     nodeSelector:
+       feature.node.kubernetes.io/network-sriov.capable: "true"
+     nicSelector:
+       nicType: "1023"  # "1025" for ConnectX-9; "a2dc" for BlueField-3 SuperNIC
+     template:
+       numVfs: 1
+       linkType: Ethernet
+       spectrumXOptimized:
+         enabled: true
+         version: "RA2.2"
+         overlay: "none"
+         multiplaneMode: "swplb"
+         numberOfPlanes: 2
+
+.. code-block:: bash
+
+   kubectl apply -f nicconfigurationtemplate.yaml
+
+==================================
+Step 5: CIDRPool (per rail-plane)
+==================================
+
+With ``swplb``, each rail is split into multiple planes, and each plane requires its own ``CIDRPool``. Create one pool per (rail, plane) combination. Replace ``TODO_*`` with subnets that match your cluster's east-west topology.
+
+.. code-block:: yaml
+
+   apiVersion: nv-ipam.nvidia.com/v1alpha1
+   kind: CIDRPool
+   metadata:
+     name: rail-0-plane-0
+     namespace: nvidia-network-operator
+   spec:
+     cidr: TODO_RAIL0_PLANE0_CIDR      # e.g., 10.0.0.0/15
+     gatewayIndex: 0
+     perNodeNetworkPrefix: 31
+     perNodeExclusions:
+       - startIndex: 1
+         endIndex: 1
+     routes:
+       - dst: TODO_RAIL0_PLANE0_SUBNET # same as cidr
+       - dst: TODO_EAST_WEST_SUBNET
+   ---
+   apiVersion: nv-ipam.nvidia.com/v1alpha1
+   kind: CIDRPool
+   metadata:
+     name: rail-0-plane-1
+     namespace: nvidia-network-operator
+   spec:
+     cidr: TODO_RAIL0_PLANE1_CIDR
+     gatewayIndex: 0
+     perNodeNetworkPrefix: 31
+     perNodeExclusions:
+       - startIndex: 1
+         endIndex: 1
+     routes:
+       - dst: TODO_RAIL0_PLANE1_SUBNET
+       - dst: TODO_EAST_WEST_SUBNET
+   ---
+   apiVersion: nv-ipam.nvidia.com/v1alpha1
+   kind: CIDRPool
+   metadata:
+     name: rail-1-plane-0
+     namespace: nvidia-network-operator
+   spec:
+     cidr: TODO_RAIL1_PLANE0_CIDR
+     gatewayIndex: 0
+     perNodeNetworkPrefix: 31
+     perNodeExclusions:
+       - startIndex: 1
+         endIndex: 1
+     routes:
+       - dst: TODO_RAIL1_PLANE0_SUBNET
+       - dst: TODO_EAST_WEST_SUBNET
+   ---
+   apiVersion: nv-ipam.nvidia.com/v1alpha1
+   kind: CIDRPool
+   metadata:
+     name: rail-1-plane-1
+     namespace: nvidia-network-operator
+   spec:
+     cidr: TODO_RAIL1_PLANE1_CIDR
+     gatewayIndex: 0
+     perNodeNetworkPrefix: 31
+     perNodeExclusions:
+       - startIndex: 1
+         endIndex: 1
+     routes:
+       - dst: TODO_RAIL1_PLANE1_SUBNET
+       - dst: TODO_EAST_WEST_SUBNET
+
+.. code-block:: bash
+
+   kubectl apply -f cidrpool.yaml
+
+================================
+Step 6: SpectrumXRailPoolConfig
+================================
+
+With ``swplb``, ``railTopology`` has one entry per (rail, plane) combination. Each entry selects a single PF (netdev name from ``NicInterfaceNameTemplate``) and references the matching per-plane ``CIDRPool``.
+
+.. code-block:: yaml
+
+   apiVersion: spectrumx.nvidia.com/v1alpha2
+   kind: SpectrumXRailPoolConfig
+   metadata:
+     name: rails
+     namespace: nvidia-network-operator
+   spec:
+     draEnabled: true
+     networkNamespace: default
+     numVfs: 1
+     railTopology:
+       - name: rail0p0
+         nicSelector:
+           pfNames: ["net_rail0_plane0"]
+         cidrPoolRef: rail-0-plane-0
+         mtu: 9216
+       - name: rail0p1
+         nicSelector:
+           pfNames: ["net_rail0_plane1"]
+         cidrPoolRef: rail-0-plane-1
+         mtu: 9216
+       - name: rail1p0
+         nicSelector:
+           pfNames: ["net_rail1_plane0"]
+         cidrPoolRef: rail-1-plane-0
+         mtu: 9216
+       - name: rail1p1
+         nicSelector:
+           pfNames: ["net_rail1_plane1"]
+         cidrPoolRef: rail-1-plane-1
+         mtu: 9216
+
+.. code-block:: bash
+
+   kubectl apply -f spectrumxrailpoolconfig.yaml
+
+================================
+Step 7: Deploy a Test Pod
+================================
+
+Request one VF per (rail, plane) combination. The network annotation lists each rail-plane and the resource request matches the corresponding DRA resource.
+
+.. code-block:: yaml
+
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: spectrum-x-test
+     namespace: default
+     annotations:
+       k8s.v1.cni.cncf.io/networks: rail0p0,rail0p1,rail1p0,rail1p1
+   spec:
+     containers:
+       - name: spectrum-x-test
+         image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+         command: ["/bin/bash", "-c", "sleep infinity"]
+         securityContext:
+           capabilities:
+             add: ["IPC_LOCK", "NET_RAW"]
+         resources:
+           requests:
+             nvidia.com/rail_0_plane_0: "1"
+             nvidia.com/rail_0_plane_1: "1"
+             nvidia.com/rail_1_plane_0: "1"
+             nvidia.com/rail_1_plane_1: "1"
+           limits:
+             nvidia.com/rail_0_plane_0: "1"
+             nvidia.com/rail_0_plane_1: "1"
+             nvidia.com/rail_1_plane_0: "1"
+             nvidia.com/rail_1_plane_1: "1"
+
+.. code-block:: bash
+
+   kubectl apply -f pod.yaml
+   kubectl -n default exec -it spectrum-x-test -- rdma link

--- a/docs/spectrum-x/quick-start.rst
+++ b/docs/spectrum-x/quick-start.rst
@@ -16,37 +16,59 @@
 
 .. headings # #, * *, =, -, ^, "
 
-**********************
-Spectrum-X Quick Start
-**********************
+*********************************
+Spectrum-X Kubernetes Quick Start
+*********************************
 
 .. note::
 
-   You can automate the configuration of these examples with NVIDIA Kubernetes Launch Kit.
-   For more details, see :doc:`Configuration Assistance with Kubernetes Launch Kit <../k8s-launch-kit/k8s-launch-kit>`.
+   These walkthroughs target **Spectrum-X RA 2.2** on **Network Operator 26.4.0**.
+   For the RA-to-release mapping and other RAs, see
+   :doc:`NVIDIA Spectrum-X <spectrum-x>`. For supported platforms (operating
+   systems, Kubernetes distributions, NIC hardware), see
+   :doc:`Platform Support <../platform-support>`.
 
-Three end-to-end examples are provided, covering the main Spectrum-X RA2.2 topologies. Each example walks through the same sequence of resources — Helm install, ``NicClusterPolicy``, ``NicInterfaceNameTemplate``, ``NicConfigurationTemplate``, ``CIDRPool``, ``SpectrumXRailPoolConfig``, and a test pod — adapted to the chosen multiplane mode and NIC family. Pick the example that matches your hardware and topology:
+   On Network Operator 26.4.0, **Single-Plane** and **Software Multiplane**
+   (``swplb``) deployments on BlueField-3 SuperNICs, ConnectX-7 NICs, and
+   ConnectX-8 SuperNICs are GA. **Hardware Multiplane** (``hwplb``) is tech
+   preview only and is not part of the validated Spectrum-X Reference
+   Architecture. For background on the operators and CNIs each walkthrough
+   relies on, see :doc:`Architecture and Components <components>`.
+
+.. tip::
+
+   The configuration in each walkthrough can be automated end-to-end with
+   NVIDIA Kubernetes Launch Kit — see
+   :doc:`Configuration Assistance with Kubernetes Launch Kit <../k8s-launch-kit/k8s-launch-kit>`.
+
+Pick the walkthrough that matches your hardware and target topology. Each one
+installs Network Operator via Helm, applies the Spectrum-X CRDs, and deploys a
+test pod — adapted to the chosen multiplane mode and NIC family.
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 15 15 45
+   :widths: 22 12 20 22 24
 
-   * - Example
+   * - Walkthrough
      - Multiplane mode
-     - Supported NICs
-     - When to use
+     - NICs
+     - GPU platforms
+     - Use when
    * - :doc:`Single Plane <quick-start-single-plane>`
      - ``none``
-     - BF3 SuperNIC, ConnectX-8, ConnectX-9
-     - Simplest setup: one PF per rail, one ``CIDRPool`` per rail, one network per rail. Best starting point for BlueField-3 SuperNIC deployments.
-   * - :doc:`Multiplane with Software Load Balancing <quick-start-swplb>`
+     - BlueField-3 SuperNIC, ConnectX-7 NIC, ConnectX-8 SuperNIC
+     - H100/H200/B200 (BlueField-3 SuperNIC), GB200 (ConnectX-7 NIC)
+     - One PF per rail. Simplest setup. ConnectX-8 SuperNIC also supports single-plane configuration.
+   * - :doc:`Software Multiplane <quick-start-swplb>`
      - ``swplb``
-     - BF3 SuperNIC, ConnectX-8, ConnectX-9
-     - Software Packet Load Balancing: each rail is split into multiple planes, with a separate ``CIDRPool`` and a separate ``railTopology`` entry per (rail, plane) combination.
-   * - :doc:`Multiplane with Hardware Load Balancing <quick-start-hwplb>`
+     - ConnectX-8 SuperNIC
+     - B300, GB300
+     - Software Plane Load Balancing across planes. Set ``numberOfPlanes: 2`` (Dual-Plane) or ``4`` (Quad-Plane, B300 only).
+   * - :doc:`Hardware Multiplane <quick-start-hwplb>` *(tech preview)*
      - ``hwplb``
-     - ConnectX-8, ConnectX-9
-     - Hardware Packet Load Balancing: NIC LAG handles the per-plane fan-out, so each rail still uses a single ``CIDRPool`` while exposing multiple per-plane PFs. Highest performance; ConnectX-8 / ConnectX-9 only.
+     - ConnectX-8 SuperNIC
+     - B300, GB300
+     - Same as ``swplb`` but Plane Load Balancing happens in the NIC hardware. **Tech preview; not RA-validated.**
 
 .. toctree::
    :maxdepth: 1
@@ -54,5 +76,5 @@ Three end-to-end examples are provided, covering the main Spectrum-X RA2.2 topol
    :hidden:
 
    Single Plane <quick-start-single-plane.rst>
-   Multiplane with Software Load Balancing <quick-start-swplb.rst>
-   Multiplane with Hardware Load Balancing <quick-start-hwplb.rst>
+   Software Multiplane <quick-start-swplb.rst>
+   Hardware Multiplane <quick-start-hwplb.rst>

--- a/docs/spectrum-x/quick-start.rst
+++ b/docs/spectrum-x/quick-start.rst
@@ -1,0 +1,58 @@
+.. license-header
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+.. headings # #, * *, =, -, ^, "
+
+**********************
+Spectrum-X Quick Start
+**********************
+
+.. note::
+
+   You can automate the configuration of these examples with NVIDIA Kubernetes Launch Kit.
+   For more details, see :doc:`Configuration Assistance with Kubernetes Launch Kit <../k8s-launch-kit/k8s-launch-kit>`.
+
+Three end-to-end examples are provided, covering the main Spectrum-X RA2.2 topologies. Each example walks through the same sequence of resources — Helm install, ``NicClusterPolicy``, ``NicInterfaceNameTemplate``, ``NicConfigurationTemplate``, ``CIDRPool``, ``SpectrumXRailPoolConfig``, and a test pod — adapted to the chosen multiplane mode and NIC family. Pick the example that matches your hardware and topology:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 15 45
+
+   * - Example
+     - Multiplane mode
+     - Supported NICs
+     - When to use
+   * - :doc:`Single Plane <quick-start-single-plane>`
+     - ``none``
+     - BF3 SuperNIC, ConnectX-8, ConnectX-9
+     - Simplest setup: one PF per rail, one ``CIDRPool`` per rail, one network per rail. Best starting point for BlueField-3 SuperNIC deployments.
+   * - :doc:`Multiplane with Software Load Balancing <quick-start-swplb>`
+     - ``swplb``
+     - BF3 SuperNIC, ConnectX-8, ConnectX-9
+     - Software Packet Load Balancing: each rail is split into multiple planes, with a separate ``CIDRPool`` and a separate ``railTopology`` entry per (rail, plane) combination.
+   * - :doc:`Multiplane with Hardware Load Balancing <quick-start-hwplb>`
+     - ``hwplb``
+     - ConnectX-8, ConnectX-9
+     - Hardware Packet Load Balancing: NIC LAG handles the per-plane fan-out, so each rail still uses a single ``CIDRPool`` while exposing multiple per-plane PFs. Highest performance; ConnectX-8 / ConnectX-9 only.
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+   :hidden:
+
+   Single Plane <quick-start-single-plane.rst>
+   Multiplane with Software Load Balancing <quick-start-swplb.rst>
+   Multiplane with Hardware Load Balancing <quick-start-hwplb.rst>

--- a/docs/spectrum-x/spectrum-x-configuration.rst
+++ b/docs/spectrum-x/spectrum-x-configuration.rst
@@ -28,11 +28,13 @@ NVIDIA Spectrum-X NIC Configuration
    :backlinks: none
 
 
-`NVIDIA NIC Configuration Operator <https://github.com/Mellanox/nic-configuration-operator>`_ offers NVIDIA Spectrum-X-specific NIC configuration for different versions of the Reference Architecture (RA1.3, RA2.0, RA2.1, and RA2.2). RA2.1 introduced multiplane mode support for enhanced network performance with multiple data planes; RA2.2 is the latest supported version.
+`NVIDIA NIC Configuration Operator <https://github.com/Mellanox/nic-configuration-operator>`_ in Network Operator 26.4.0 supports **Spectrum-X RA 2.2** as the validated reference architecture. The ``spectrumXOptimized.version`` CRD field also accepts **RA 1.3**, **RA 2.0**, and **RA 2.1** for legacy or mixed-version configurations. RA 2.1 introduced multiplane mode support for enhanced network performance with multiple data planes; **RA 2.2 is the latest** and the validated default.
+
+For the Network Operator Spectrum-X RA support matrix and validated hardware, operating system, and Kubernetes combinations, see :doc:`Platform Support <../platform-support>`.
 
 .. note::
 
-   Currently, only ConnectX-8 (device ID ``1023``), ConnectX-9 (device ID ``1025``), and BlueField-3 SuperNIC (device ID ``a2dc``) devices are supported for Spectrum-X configuration. Hardware Packet Load Balancing (``hwplb``) multiplane mode is only supported on ConnectX-8 and ConnectX-9, and only with RA2.2.
+   Currently, ConnectX-7 NIC (device ID ``1021``), ConnectX-8 SuperNIC (device ID ``1023``), and BlueField-3 SuperNIC (device ID ``a2dc``) devices are supported for Spectrum-X configuration. Hardware Plane Load Balancing (``hwplb``) is supported only on ConnectX-8 SuperNIC with RA 2.2, and is **tech preview** — it is not part of the validated Spectrum-X Reference Architecture.
 
 
 ====================================================
@@ -110,19 +112,19 @@ The following multiplane modes are available with RA2.1 and RA2.2:
      - **Planes**
    * - ``none``
      - Single plane mode (no multiplane). This is the default.
-     - ConnectX-8, ConnectX-9, BF3 SuperNIC
+     - BlueField-3 SuperNIC, ConnectX-7 NIC, ConnectX-8 SuperNIC
      - 1
    * - ``swplb``
-     - Software Packet Load Balancing. The NIC port is split into multiple PFs, each assigned to a separate data plane.
-     - ConnectX-8, ConnectX-9, BF3 SuperNIC
+     - Software Plane Load Balancing. The NIC port is split into multiple PFs, each assigned to a separate data plane; the software stack distributes packets across planes.
+     - ConnectX-8 SuperNIC
      - 2, 4
-   * - ``hwplb``
-     - Hardware Packet Load Balancing. Uses hardware LAG resource allocation and NIC-level plane configuration for load balancing across planes. RA2.2 only.
-     - ConnectX-8, ConnectX-9 only
+   * - ``hwplb`` *(tech preview)*
+     - Hardware Plane Load Balancing. Uses hardware LAG resource allocation and NIC-level plane configuration to distribute packets across planes in the NIC hardware. RA 2.2 only. **Tech preview; not part of the validated Reference Architecture.**
+     - ConnectX-8 SuperNIC
      - 2, 4
    * - ``uniplane``
-     - Uniplane mode. Each port is configured as a separate plane without plane-level load balancing.
-     - ConnectX-8, ConnectX-9, BF3 SuperNIC
+     - Uniplane mode. Single-plane physical topology that uses the Spectrum-X multi-plane software stack and IP schema — multiple PFs all connect to the **same** ToR/plane (rather than separate planes as in ``swplb`` / ``hwplb``). Specialized configuration for compatibility or regression scenarios; for production deployments, use ``none`` for Single-Plane or ``swplb`` / ``hwplb`` for Dual-Plane / Quad-Plane.
+     - ConnectX-8 SuperNIC
      - 2
 
 .. note::
@@ -139,19 +141,19 @@ NIC type constraints
    * - **NIC Type**
      - **Device ID**
      - **Supported Multiplane Modes**
-   * - ConnectX-8
+   * - ConnectX-7 NIC
+     - ``1021``
+     - ``none``
+   * - ConnectX-8 SuperNIC
      - ``1023``
-     - ``none``, ``swplb``, ``hwplb``, ``uniplane``
-   * - ConnectX-9
-     - ``1025``
      - ``none``, ``swplb``, ``hwplb``, ``uniplane``
    * - BlueField-3 SuperNIC
      - ``a2dc``
-     - ``none``, ``swplb``, ``uniplane``
+     - ``none``
 
 .. warning::
 
-   The ``hwplb`` multiplane mode is only supported on ConnectX-8 (device ID ``1023``) and ConnectX-9 (device ID ``1025``), and only with RA2.2. Attempting to configure ``hwplb`` on a BlueField-3 SuperNIC, or with an RA version other than RA2.2, will be rejected by the API validation.
+   The ``hwplb`` multiplane mode is supported only on ConnectX-8 SuperNIC (device ID ``1023``) with RA 2.2, and is **tech preview** — it is not part of the validated Spectrum-X Reference Architecture. Attempting to configure ``hwplb`` on BlueField-3 SuperNIC or ConnectX-7 NIC, or with an RA version other than RA 2.2, will be rejected by the API validation.
 
 Configure custom interface names
 ---------------------------------
@@ -201,6 +203,13 @@ Example generated udev rules for RDMA devices (``/etc/udev/rules.d/10-nic-rdma-i
    ACTION=="add", KERNELS=="0000:3a:00.0", SUBSYSTEM=="infiniband", RUN+="/usr/bin/rdma dev set %k name rdma_1_0_1"
    ACTION=="add", KERNELS=="0000:3a:00.1", SUBSYSTEM=="infiniband", RUN+="/usr/bin/rdma dev set %k name rdma_1_1_1"
 
+.. note::
+
+   The actual generated names depend on the ``netDevicePrefix`` /
+   ``rdmaDevicePrefix`` you set on the ``NicInterfaceNameTemplate`` — see
+   the Quick-Start walkthroughs for the recommended rail / plane-based
+   naming (for example, ``net_rail0_plane0``).
+
 ================
 Validation rules
 ================
@@ -208,10 +217,10 @@ Validation rules
 The following validation rules are enforced by the API:
 
 - Spectrum-X optimizations can only be enabled when ``linkType`` is ``Ethernet`` and ``numVfs`` is ``1``.
-- Spectrum-X optimizations can only be enabled for ConnectX-8 (``nicType: 1023``), ConnectX-9 (``nicType: 1025``), or BlueField-3 SuperNIC (``nicType: a2dc``).
+- Spectrum-X optimizations can only be enabled for ConnectX-7 NIC (``nicType: 1021``), ConnectX-8 SuperNIC (``nicType: 1023``), or BlueField-3 SuperNIC (``nicType: a2dc``).
 - When Spectrum-X optimizations are enabled, ``roceOptimized`` must not be enabled (RoCE settings are included in the Spectrum-X configuration).
 - When Spectrum-X optimizations are enabled, ``rawNvConfig`` must be empty.
 - When ``multiplaneMode`` is ``none``, ``numberOfPlanes`` must be ``1``.
 - When ``multiplaneMode`` is not ``none``, ``numberOfPlanes`` must not be ``1``.
 - When ``version`` is ``RA1.3`` or ``RA2.0``, ``multiplaneMode`` must be ``none`` and ``numberOfPlanes`` must be ``1``.
-- The ``hwplb`` multiplane mode can only be enabled for ConnectX-8 (``nicType: 1023``) or ConnectX-9 (``nicType: 1025``), and only with ``version: RA2.2``.
+- The ``hwplb`` multiplane mode can only be enabled for ConnectX-8 SuperNIC (``nicType: 1023``), and only with ``version: RA 2.2``. ``hwplb`` is tech preview and is not part of the validated Reference Architecture.

--- a/docs/spectrum-x/spectrum-x-configuration.rst
+++ b/docs/spectrum-x/spectrum-x-configuration.rst
@@ -18,9 +18,9 @@
 
 .. include:: ../common/vars.rst
 
-**************************************************
-[TECH PREVIEW] NVIDIA Spectrum-X NIC Configuration
-**************************************************
+***********************************
+NVIDIA Spectrum-X NIC Configuration
+***********************************
 
 .. contents:: On this page
    :depth: 4
@@ -28,18 +28,18 @@
    :backlinks: none
 
 
-`NVIDIA NIC Configuration Operator <https://github.com/Mellanox/nic-configuration-operator>`_ offers NVIDIA Spectrum-X-specific NIC configuration for different versions of the Reference Architecture (RA1.3, RA2.0, and RA2.1). RA2.1 introduces multiplane mode support for enhanced network performance with multiple data planes.
+`NVIDIA NIC Configuration Operator <https://github.com/Mellanox/nic-configuration-operator>`_ offers NVIDIA Spectrum-X-specific NIC configuration for different versions of the Reference Architecture (RA1.3, RA2.0, RA2.1, and RA2.2). RA2.1 introduced multiplane mode support for enhanced network performance with multiple data planes; RA2.2 is the latest supported version.
 
 .. note::
 
-   Currently, only ConnectX-8 (device ID ``1023``) and BlueField-3 SuperNIC (device ID ``a2dc``) devices are supported for Spectrum-X configuration. Hardware Packet Load Balancing (``hwplb``) multiplane mode is only supported on ConnectX-8.
+   Currently, only ConnectX-8 (device ID ``1023``), ConnectX-9 (device ID ``1025``), and BlueField-3 SuperNIC (device ID ``a2dc``) devices are supported for Spectrum-X configuration. Hardware Packet Load Balancing (``hwplb``) multiplane mode is only supported on ConnectX-8 and ConnectX-9, and only with RA2.2.
 
 
 ====================================================
 Install and Configure the NIC Configuration Operator
 ====================================================
 
-To install the operator and for more information on the CRDs, see :doc:`nic-fw-configuration` and :doc:`configuration-details`.
+To install the operator and for more information on the CRDs, see :doc:`NIC Firmware Configuration <../nic-conf-operator/nic-fw-configuration>` and :doc:`Configuration Details <../nic-conf-operator/configuration-details>`.
 
 =============================================
 Provision the DOCA SPC-X CC Algorithm Package
@@ -81,15 +81,15 @@ Enable SPC-X Optimizations for Devices
     :lines: 18-
 
 
-RA2.1 configuration with multiplane support
---------------------------------------------
+RA2.1 / RA2.2 configuration with multiplane support
+----------------------------------------------------
 
-Reference Architecture 2.1 introduces multiplane mode support, allowing NICs to be configured with multiple data planes for enhanced network performance.
+Reference Architecture 2.1 introduced multiplane mode support, allowing NICs to be configured with multiple data planes for enhanced network performance. RA2.2 extends this support and is the latest supported version.
 
 .. note::
-   It is recommended to perform a NIC configuration reset before applying or switching between multiplane configurations to ensure a clean and consistent initial state. See :doc:`Reset NIC Configuration to Default <nic-fw-configuration>` for details.
+   It is recommended to perform a NIC configuration reset before applying or switching between multiplane configurations to ensure a clean and consistent initial state. See :doc:`Reset NIC Configuration to Default <../nic-conf-operator/nic-fw-configuration>` for details.
 
-To enable multiplane support, set ``spectrumXOptimized.version`` to ``RA2.1`` and configure the ``multiplaneMode`` and ``numberOfPlanes`` fields.
+To enable multiplane support, set ``spectrumXOptimized.version`` to ``RA2.1`` or ``RA2.2`` and configure the ``multiplaneMode`` and ``numberOfPlanes`` fields.
 
 .. rli:: https://raw.githubusercontent.com/Mellanox/nic-configuration-operator/refs/tags/network-operator-|network-operator-version|/docs/examples/spectrum-x/example-nicconfigurationtemplate-spectrum-x-multiplane.yaml
     :language: yaml
@@ -98,7 +98,7 @@ To enable multiplane support, set ``spectrumXOptimized.version`` to ``RA2.1`` an
 Multiplane modes
 ^^^^^^^^^^^^^^^^
 
-The following multiplane modes are available with RA2.1:
+The following multiplane modes are available with RA2.1 and RA2.2:
 
 .. list-table::
    :header-rows: 1
@@ -110,24 +110,24 @@ The following multiplane modes are available with RA2.1:
      - **Planes**
    * - ``none``
      - Single plane mode (no multiplane). This is the default.
-     - ConnectX-8, BF3 SuperNIC
+     - ConnectX-8, ConnectX-9, BF3 SuperNIC
      - 1
    * - ``swplb``
      - Software Packet Load Balancing. The NIC port is split into multiple PFs, each assigned to a separate data plane.
-     - ConnectX-8, BF3 SuperNIC
+     - ConnectX-8, ConnectX-9, BF3 SuperNIC
      - 2, 4
    * - ``hwplb``
-     - Hardware Packet Load Balancing. Uses hardware LAG resource allocation and NIC-level plane configuration for load balancing across planes.
-     - ConnectX-8 only
+     - Hardware Packet Load Balancing. Uses hardware LAG resource allocation and NIC-level plane configuration for load balancing across planes. RA2.2 only.
+     - ConnectX-8, ConnectX-9 only
      - 2, 4
    * - ``uniplane``
      - Uniplane mode. Each port is configured as a separate plane without plane-level load balancing.
-     - ConnectX-8, BF3 SuperNIC
+     - ConnectX-8, ConnectX-9, BF3 SuperNIC
      - 2
 
 .. note::
 
-   Multiplane modes (``swplb``, ``hwplb``, ``uniplane``) are only supported with RA2.1. For RA1.3 and RA2.0, ``multiplaneMode`` must be ``none`` and ``numberOfPlanes`` must be ``1``.
+   Multiplane modes (``swplb``, ``hwplb``, ``uniplane``) are only supported with RA2.1 and RA2.2. For RA1.3 and RA2.0, ``multiplaneMode`` must be ``none`` and ``numberOfPlanes`` must be ``1``.
 
 NIC type constraints
 ^^^^^^^^^^^^^^^^^^^^
@@ -142,13 +142,16 @@ NIC type constraints
    * - ConnectX-8
      - ``1023``
      - ``none``, ``swplb``, ``hwplb``, ``uniplane``
+   * - ConnectX-9
+     - ``1025``
+     - ``none``, ``swplb``, ``hwplb``, ``uniplane``
    * - BlueField-3 SuperNIC
      - ``a2dc``
      - ``none``, ``swplb``, ``uniplane``
 
 .. warning::
 
-   The ``hwplb`` multiplane mode is only supported on ConnectX-8 (device ID ``1023``). Attempting to configure ``hwplb`` on a BlueField-3 SuperNIC will be rejected by the API validation.
+   The ``hwplb`` multiplane mode is only supported on ConnectX-8 (device ID ``1023``) and ConnectX-9 (device ID ``1025``), and only with RA2.2. Attempting to configure ``hwplb`` on a BlueField-3 SuperNIC, or with an RA version other than RA2.2, will be rejected by the API validation.
 
 Configure custom interface names
 ---------------------------------
@@ -205,10 +208,10 @@ Validation rules
 The following validation rules are enforced by the API:
 
 - Spectrum-X optimizations can only be enabled when ``linkType`` is ``Ethernet`` and ``numVfs`` is ``1``.
-- Spectrum-X optimizations can only be enabled for ConnectX-8 (``nicType: 1023``) or BlueField-3 SuperNIC (``nicType: a2dc``).
+- Spectrum-X optimizations can only be enabled for ConnectX-8 (``nicType: 1023``), ConnectX-9 (``nicType: 1025``), or BlueField-3 SuperNIC (``nicType: a2dc``).
 - When Spectrum-X optimizations are enabled, ``roceOptimized`` must not be enabled (RoCE settings are included in the Spectrum-X configuration).
 - When Spectrum-X optimizations are enabled, ``rawNvConfig`` must be empty.
 - When ``multiplaneMode`` is ``none``, ``numberOfPlanes`` must be ``1``.
 - When ``multiplaneMode`` is not ``none``, ``numberOfPlanes`` must not be ``1``.
 - When ``version`` is ``RA1.3`` or ``RA2.0``, ``multiplaneMode`` must be ``none`` and ``numberOfPlanes`` must be ``1``.
-- The ``hwplb`` multiplane mode can only be enabled for ConnectX-8 (``nicType: 1023``).
+- The ``hwplb`` multiplane mode can only be enabled for ConnectX-8 (``nicType: 1023``) or ConnectX-9 (``nicType: 1025``), and only with ``version: RA2.2``.

--- a/docs/spectrum-x/spectrum-x.rst
+++ b/docs/spectrum-x/spectrum-x.rst
@@ -16,14 +16,138 @@
 
 .. headings # #, * *, =, -, ^, "
 
-*****************
-NVIDIA Spectrum-X
-*****************
+**********************************************
+NVIDIA Spectrum-X Ethernet Networking Platform
+**********************************************
+
+.. note::
+
+   This section covers **NVIDIA Network Operator configuration** to enable
+   NVIDIA Spectrum-X NIC setup in Kubernetes deployments. For the full
+   Spectrum-X platform documentation — supported topologies, NIC hardware,
+   software components, and version-specific notes — refer to the
+   `NVIDIA Spectrum-X documentation <https://www.nvidia.com/en-us/networking/spectrumx/>`_.
+
+NVIDIA Spectrum-X is an AI-optimized Ethernet networking platform that combines
+NVIDIA Spectrum switches with the BlueField-3 SuperNIC, ConnectX-7 NIC, and
+ConnectX-8 SuperNIC families to deliver high-bandwidth, lossless RoCE for the
+GPU-to-GPU compute (east-west) network. NVIDIA Network Operator provides the
+Kubernetes side: discovering the NICs, configuring rails, and exposing them
+to pods as schedulable resources.
+
+**Spectrum-X Multiplane.** Spectrum-X Multiplane is the Spectrum-X capability
+that splits each SuperNIC across two or more independent network planes —
+enabling Ethernet to scale from thousands to hundreds of thousands of GPUs in
+a flat, two-tier topology, with improved performance and resiliency over
+single-plane networks. Network Operator exposes it through the
+``multiplaneMode`` field on ``NicConfigurationTemplate``, with
+**Software Multiplane** (``swplb``) and **Hardware Multiplane** (``hwplb``,
+tech preview) variants alongside the default single-plane mode (``none``).
+
+**Architecture and multiplane modes.** Spectrum-X Kubernetes deployments fall
+into three network architectures, distinguished by the number of planes per
+rail and the load-balancing mechanism:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 20 22 22 18
+
+   * - Architecture
+     - NICs
+     - GPU platforms
+     - Multiplane mode
+     - Status
+   * - Single-Plane
+     - BlueField-3 SuperNIC, ConnectX-7 NIC, ConnectX-8 SuperNIC
+     - H100/H200/B200, GB200
+     - ``none`` (1 plane)
+     - GA
+   * - Dual-Plane
+     - ConnectX-8 SuperNIC
+     - B300, GB300
+     - | ``swplb`` (2 planes)
+       | ``hwplb`` (2 planes)
+     - | ``swplb`` — GA
+       | ``hwplb`` — Tech preview
+   * - Quad-Plane
+     - ConnectX-8 SuperNIC
+     - B300
+     - | ``swplb`` (4 planes)
+       | ``hwplb`` (4 planes)
+     - | ``swplb`` — GA
+       | ``hwplb`` — Tech preview
+
+.. note::
+
+   ConnectX-8 SuperNIC is listed in the Single-Plane row because it also
+   supports single-plane (``none``) configuration. Typical Single-Plane
+   deployments use BlueField-3 SuperNIC (HGX H100/H200/B200) or ConnectX-7
+   NIC (GB200).
+
+**Version compatibility.** Each Spectrum-X Reference Architecture version is
+supported by a specific Network Operator release:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Spectrum-X RA Version
+     - NVIDIA Network Operator Release
+   * - Spectrum-X RA 2.2
+     - 26.4.0
+   * - Spectrum-X RA 2.1
+     - 26.1.0
+
+While each Network Operator release is **validated end-to-end** with a
+specific Spectrum-X RA version, individual components support a wider range
+of RAs in their configuration CRDs. For example, NIC Configuration Operator
+in 26.4.0 accepts ``spectrumXOptimized.version`` values **RA1.3**, **RA2.0**,
+**RA2.1**, and **RA2.2**. See :doc:`Spectrum-X NIC Configuration
+<spectrum-x-configuration>` for details.
+
+**Configuration surface.** Network Operator drives Spectrum-X setup through a
+small set of CRDs that work together:
+
+- ``NicClusterPolicy`` --- cluster-wide Network Operator configuration that
+  enables the Spectrum-X Operator, SR-IOV Network Operator, NIC Configuration
+  Operator, NV-IPAM, and Multus.
+- ``NicConfigurationTemplate`` --- NIC-level firmware/PF configuration for
+  Spectrum-X (link type, ``numVfs``, multiplane mode, RA version).
+- ``NicInterfaceNameTemplate`` --- predictable rail/plane-based netdev names
+  driven by udev rules.
+- ``SpectrumXRailPoolConfig`` (``spectrumx.nvidia.com/v1alpha2``) --- rail
+  topology, PF selection, IPAM binding, and DRA / SR-IOV resource exposure.
+- ``CIDRPool`` (NV-IPAM) --- IP allocation per rail (or per rail/plane in
+  ``swplb``).
+
+For Dynamic Resource Allocation workflows (tech preview), the upstream
+Kubernetes ``ResourceClaimTemplate`` resource binds pod requests to specific
+GPU + VF combinations.
+
+For the full operator / driver / CNI stack that backs these CRDs and how the
+components depend on each other, see :doc:`Architecture and Components
+<components>`.
+
+**Further reading:**
+
+- **Supported platforms** (servers, NICs, switches, cables, OS combinations for
+  each Spectrum-X release): see the `NVIDIA Spectrum-X Solution Stack
+  documentation
+  <https://docs.nvidia.com/networking/software/spectrumx-solution-stack/index.html>`_.
+- **Network Operator Kubernetes matrix** (operating systems, Kubernetes
+  distribution versions, and the Spectrum-X RA support row): see
+  :doc:`Platform Support <../platform-support>`.
+- **Component versions** for Network Operator, Spectrum-X Operator, NIC
+  Configuration Operator, NV-IPAM, and the SR-IOV DRA driver: see the software
+  components table in :doc:`Platform Support <../platform-support>`.
+
+When you're ready to deploy, continue to the Quick Start walkthroughs:
 
 .. toctree::
-  :maxdepth: 1
-  :titlesonly:
+   :maxdepth: 1
+   :titlesonly:
 
    Quick Start <quick-start.rst>
+   Architecture and Components <components.rst>
    Spectrum-X NIC Configuration <spectrum-x-configuration.rst>
    CRD API Reference <crds.rst>

--- a/docs/spectrum-x/spectrum-x.rst
+++ b/docs/spectrum-x/spectrum-x.rst
@@ -1,5 +1,5 @@
 .. license-header
-  SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
   SPDX-License-Identifier: Apache-2.0
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,14 +16,14 @@
 
 .. headings # #, * *, =, -, ^, "
 
-**************************
-NIC Configuration Operator
-**************************
+*****************
+NVIDIA Spectrum-X
+*****************
 
 .. toctree::
   :maxdepth: 1
   :titlesonly:
 
-   NIC Firmware Configuration <nic-fw-configuration.rst>
-   Configuration Details <configuration-details.rst>
+   Quick Start <quick-start.rst>
+   Spectrum-X NIC Configuration <spectrum-x-configuration.rst>
    CRD API Reference <crds.rst>


### PR DESCRIPTION
## Summary

Aligns the Spectrum-X documentation section with **Network Operator v26.4.x** and **Spectrum-X Reference Architecture 2.2**, and refactors the Components page into a clean Host vs Kubernetes domain split for partner-friendly readability.

## Scope

`docs/spectrum-x/` only — 8 files (7 modified, 1 new):

- `spectrum-x.rst` (landing) — Multiplane intro, architecture table polish, CRD list expansion
- `quick-start.rst` (chooser) — naming and terminology
- `quick-start-{single-plane,swplb,hwplb}.rst` — walkthroughs, NIC naming, YAML annotations
- `spectrum-x-configuration.rst` — modes table, **uniplane** description fix, udev caveat
- `crds.rst` — CRD reference
- `components.rst` (**new**) — Architecture and Components page (Host Layer / Kubernetes Layer split)

## Highlights

- **NIC naming** standardized: BlueField-3 SuperNIC, ConnectX-7 NIC, ConnectX-8 SuperNIC
- **Multiplane** (one word) standardized as the official Spectrum-X capability name; "Packet Load Balancing" corrected to **Plane Load Balancing** (PLB = Plane, per Spectrum-X K8s architecture spec)
- New **Architecture and Components** page with explicit Host vs Kubernetes layer split, Stack overview, Deployment ownership table (Day 0/1/2), Dependencies and ordering, and DOCA-Host vs containerized DOCA-OFED mutual-exclusion callout
- **Uniplane** description fixed (was incorrectly claiming "separate plane"; uniplane is actually a single-plane physical topology that runs the multi-plane software stack — multiple PFs to the *same* ToR/plane)
- Architecture table polished: cleaner column headers, multi-line stacking for `swplb` / `hwplb` rows

## Verified against

- `github.com/Mellanox/network-operator` (v26.4.x)
- `github.com/Mellanox/spectrum-x-operator` (network-operator-26.4.x)
- `github.com/Mellanox/nic-configuration-operator` (network-operator-26.4.x)

All CRD field names, enum values, validation rules, and YAML examples in the docs match the actual operator APIs.

## Test plan

- [x] Sphinx build passes with no warnings on Spectrum-X content
- [x] All `:doc:` and `:ref:` cross-references resolve
- [x] Renders verified locally in browser (landing, chooser, all three walkthroughs, components, configuration, CRDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)