### PR TITLE
docs: Spectrum-X RA 2.2 consistency pass (DRA, Launch Kit, NIC Config Operator)

### DIFF
--- a/docs/dra-sriov-driver/dra-sriov-driver.rst
+++ b/docs/dra-sriov-driver/dra-sriov-driver.rst
@@ -31,6 +31,11 @@ specialized devices like SR-IOV network interfaces. DRA puts device configuratio
 of device vendors through drivers such as the DRA Driver for SR-IOV. This page outlines how to install the
 NVIDIA DRA Driver for SR-IOV with the NVIDIA Network Operator.
 
+.. note::
+
+   The DRA Driver for SR-IOV is a **Tech Preview** feature: it has limited testing and is not
+   recommended for production deployments. See :doc:`Platform Support <../platform-support>` for support-tier definitions.
+
 Before using the DRA Driver for SR-IOV, it is recommended that you are familiar with the following concepts:
 
 * `Upstream Kubernetes DRA documentation <https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/>`_.

--- a/docs/k8s-launch-kit/heterogeneous-clusters.rst
+++ b/docs/k8s-launch-kit/heterogeneous-clusters.rst
@@ -28,7 +28,7 @@ Heterogeneous Clusters
 
 .. note::
 
-   **Use this when:** your cluster contains multiple node types --- e.g., different GPU SKUs (H100 + H200), different NIC SKUs (ConnectX-7 + BF3 SuperNIC), or different OFED requirements.
+   **Use this when:** your cluster contains multiple node types --- e.g., different GPU SKUs (H100 + H200), different NIC SKUs (ConnectX-7 NIC + BlueField-3 SuperNIC), or different OFED requirements.
 
 ================================================================================
 Supported Configurations
@@ -319,8 +319,8 @@ The classification uses an embedded list of DPU product codes. BlueField-3 Super
 
        subgraph Node[Compute node]
            direction TB
-           BF3[BF3 DPU<br/>north-south]
-           SUPER[ConnectX-7 / BF3 SuperNIC<br/>east-west]
+           BF3[BlueField-3 DPU<br/>north-south]
+           SUPER[ConnectX-7 NIC / BlueField-3 SuperNIC<br/>east-west]
            GPU[GPUs]
            GPU --- SUPER
        end

--- a/docs/k8s-launch-kit/overview.rst
+++ b/docs/k8s-launch-kit/overview.rst
@@ -136,12 +136,12 @@ Spectrum-X Multiplane Modes
 
 Spectrum-X profiles add a **multiplane mode** dimension on top of profile selection:
 
-- ``hwplb`` --- hardware plane load balancing (large 2- or 3-tier switch topologies)
+- ``hwplb`` --- hardware plane load balancing (large 2- or 3-tier switch topologies; tech preview, ConnectX-8 SuperNIC only)
 - ``swplb`` --- software plane load balancing (smaller-scale Spectrum-X clusters)
 - ``uniplane`` --- single unified plane (forces ``--number-of-planes 1``)
-- ``none`` --- no plane separation (BlueField-3 SuperNIC; simple topologies)
+- ``none`` --- no plane separation (ConnectX-7 NIC, BlueField-3 SuperNIC; simple topologies)
 
-NIC type constrains available modes (ConnectX-8 supports ``swplb``/``hwplb``/``uniplane``; BF3 SuperNIC supports ``none`` only). See :doc:`profiles/spectrum-x`.
+NIC type constrains available modes: ConnectX-7 NIC and BlueField-3 SuperNIC support ``none`` only; ConnectX-8 SuperNIC supports ``none``, ``swplb``, ``hwplb`` (tech preview), and ``uniplane``. See :doc:`profiles/spectrum-x`.
 
 ================================================================================
 Cluster Topology Presets

--- a/docs/k8s-launch-kit/profiles/profiles.rst
+++ b/docs/k8s-launch-kit/profiles/profiles.rst
@@ -107,7 +107,7 @@ Decision Matrix
      - ethernet / rdma_shared
      - MacVLAN, multi-tenant, network-segmentation
    * - :doc:`Spectrum-X <spectrum-x>`
-     - NVIDIA Spectrum-X multi-rail AI interconnect (RA2.1 or RA2.2). HWPLB / SWPLB / Uniplane / None modes.
+     - NVIDIA Spectrum-X multi-rail AI interconnect (RA2.1 or RA2.2). HWPLB (tech preview) / SWPLB / Uniplane / None modes.
      - ethernet / sriov / spectrum-x
      - Spectrum-X, multiplane, RA2.2, HWPLB
 

--- a/docs/k8s-launch-kit/profiles/spectrum-x.rst
+++ b/docs/k8s-launch-kit/profiles/spectrum-x.rst
@@ -48,7 +48,7 @@ The ``--multiplane-mode`` flag selects how planes are mapped onto NICs. ``--spec
 HWPLB
 ------
 
-Hardware Plane Load Balancing for larger-scale clusters with 2-tier or 3-tier switch topologies:
+Hardware Plane Load Balancing for larger-scale clusters with 2-tier or 3-tier switch topologies. **Tech preview**, supported on ConnectX-8 SuperNIC with RA2.2 only --- not part of the validated Spectrum-X Reference Architecture:
 
 .. code-block:: bash
 
@@ -70,7 +70,7 @@ Software Plane Load Balancing for smaller-scale Spectrum-X clusters. Generates s
 Uniplane
 ---------
 
-Unified plane mode with no plane separation. Use with ``--number-of-planes 1``:
+Single-plane physical topology that runs the Spectrum-X multiplane software stack and IP schema --- multiple PFs all connect to the **same** ToR/plane (rather than separate planes as in ``swplb`` / ``hwplb``). A specialized configuration for compatibility or regression scenarios; for production, use ``none`` for Single-Plane or ``swplb`` / ``hwplb`` for Dual-Plane / Quad-Plane. Supported on ConnectX-8 SuperNIC only. Use with ``--number-of-planes 1``:
 
 .. code-block:: bash
 
@@ -81,7 +81,7 @@ Unified plane mode with no plane separation. Use with ``--number-of-planes 1``:
 None (Single Plane)
 --------------------
 
-No multiplane separation. Use with BlueField-3 SuperNIC or simple topologies. ``none`` requires ``--number-of-planes 1``:
+No multiplane separation. Use with ConnectX-7 NIC, BlueField-3 SuperNIC, or simple topologies. ``none`` requires ``--number-of-planes 1``:
 
 .. code-block:: bash
 
@@ -124,12 +124,18 @@ NIC Type Constraints
    * - **NIC Type**
      - **Device ID**
      - **Supported Modes**
-   * - ConnectX-8
-     - ``1023``
-     - ``swplb``, ``hwplb``, ``uniplane``
+   * - ConnectX-7 NIC
+     - ``1021``
+     - ``none`` only
    * - BlueField-3 SuperNIC
      - ``a2dc``
      - ``none`` only
+   * - ConnectX-8 SuperNIC
+     - ``1023``
+     - | ``none``
+       | ``swplb``
+       | ``hwplb`` *(tech preview)*
+       | ``uniplane``
 
 ================================================================================
 Pinning to RA2.1

--- a/docs/k8s-launch-kit/reference/config.rst
+++ b/docs/k8s-launch-kit/reference/config.rst
@@ -277,7 +277,7 @@ Spectrum-X-specific settings.
    * - **Field**
      - **Description**
    * - ``nicType``
-     - NIC type device ID. ``1023`` = ConnectX-8; ``a2dc`` = BlueField-3 SuperNIC.
+     - NIC type device ID. ``1021`` = ConnectX-7 NIC; ``1023`` = ConnectX-8 SuperNIC; ``a2dc`` = BlueField-3 SuperNIC.
    * - ``overlay``
      - Overlay mode.
    * - ``rdmaPrefix``

--- a/docs/nic-conf-operator/configuration-details.rst
+++ b/docs/nic-conf-operator/configuration-details.rst
@@ -74,62 +74,116 @@ Configuration details
   - Requires ``linkType=Ethernet`` and ``numVfs=1``
   - Cannot be combined with ``roceOptimized`` (RoCE settings are included automatically)
   - Can be combined with ``rawNvConfig`` — raw params are merged as overrides on top of Spectrum-X calculated params
-  - Only supported on ConnectX-8 (``nicType: 1023``), ConnectX-9 (``nicType: 1025``) and BlueField-3 SuperNIC (``nicType: a2dc``)
+  - Only supported on ConnectX-7 NIC (``nicType: 1021``), ConnectX-8 SuperNIC (``nicType: 1023``) and BlueField-3 SuperNIC (``nicType: a2dc``)
   - ``version``: Required. Reference Architecture version (``RA1.3``, ``RA2.0``, ``RA2.1``, or ``RA2.2``)
   - ``overlay``: Optional, default ``none``. Set to ``l3`` for L3 EVPN overlay
-  - ``multiplaneMode``: Optional, default ``none``. Only available with RA2.1. Options: ``none``, ``swplb``, ``hwplb``, ``uniplane``
-  - ``numberOfPlanes``: Optional, default ``1``. Only available with RA2.1. Options: ``1``, ``2``, or ``4``
+  - ``multiplaneMode``: Optional, default ``none``. Available with RA2.1 and RA2.2. Options: ``none``, ``swplb``, ``hwplb`` (tech preview), ``uniplane``
+  - ``numberOfPlanes``: Optional, default ``1``. Available with RA2.1 and RA2.2. Options: ``1``, ``2``, or ``4``
 
 - If a configuration is not set in spec, its non-volatile configuration parameters (if any) should be set to device default.
 
 Spectrum-X Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The NIC Configuration Operator supports Spectrum-X-specific NIC configuration for different versions of the NVIDIA Spectrum-X Reference Architecture (RA1.3, RA2.0, and RA2.1).
+The NIC Configuration Operator supports Spectrum-X-specific NIC configuration for different versions of the NVIDIA Spectrum-X Reference Architecture (RA1.3, RA2.0, RA2.1, and RA2.2).
 
-Supported NIC types for Spectrum-X: \* ConnectX-8 (device ID ``1023``) – supports all multiplane modes \* ConnectX-9 (device ID ``1025``) – supports all multiplane modes (same configuration as ConnectX-8) \* BlueField-3 SuperNIC (device ID ``a2dc``) – supports all multiplane modes except ``hwplb``
+Supported NIC types for Spectrum-X: \* ConnectX-7 NIC (device ID ``1021``) – supports ``none`` only \* ConnectX-8 SuperNIC (device ID ``1023``) – supports all multiplane modes \* BlueField-3 SuperNIC (device ID ``a2dc``) – supports ``none`` only
 
-RA2.1 introduces multiplane mode support, allowing NICs to be configured with multiple data planes. Available modes:
+RA2.1 and RA2.2 introduce multiplane mode support, allowing NICs to be configured with multiple data planes. Available modes:
 
-+--------------+--------------------------------+--------------------------------------+------------+
-| Mode         | Description                    | Supported NICs                       | Planes     |
-+==============+================================+======================================+============+
-| ``none``     | Single plane (default)         | ConnectX-8, ConnectX-9, BF3 SuperNIC | 1          |
-+--------------+--------------------------------+--------------------------------------+------------+
-| ``swplb``    | Software Packet Load Balancing | ConnectX-8, ConnectX-9, BF3 SuperNIC | 2, 4       |
-+--------------+--------------------------------+--------------------------------------+------------+
-| ``hwplb``    | Hardware Packet Load Balancing | ConnectX-8, ConnectX-9 only          | 2, 4       |
-+--------------+--------------------------------+--------------------------------------+------------+
-| ``uniplane`` | Uniplane mode                  | ConnectX-8, ConnectX-9, BF3 SuperNIC | 2          |
-+--------------+--------------------------------+--------------------------------------+------------+
++--------------+----------------------------------------------+-----------------------------------------------------------+--------+
+| Mode         | Description                                  | Supported NICs                                            | Planes |
++==============+==============================================+===========================================================+========+
+| ``none``     | Single plane (default)                       | ConnectX-7 NIC, BlueField-3 SuperNIC, ConnectX-8 SuperNIC | 1      |
++--------------+----------------------------------------------+-----------------------------------------------------------+--------+
+| ``swplb``    | Software Plane Load Balancing                | ConnectX-8 SuperNIC                                       | 2, 4   |
++--------------+----------------------------------------------+-----------------------------------------------------------+--------+
+| ``hwplb``    | Hardware Plane Load Balancing (tech preview) | ConnectX-8 SuperNIC                                       | 2, 4   |
++--------------+----------------------------------------------+-----------------------------------------------------------+--------+
+| ``uniplane`` | Uniplane mode                                | ConnectX-8 SuperNIC                                       | 2      |
++--------------+----------------------------------------------+-----------------------------------------------------------+--------+
 
 ..
 
-   **Note:** Multiplane modes are only available with RA2.1. For RA1.3 and RA2.0, ``multiplaneMode`` must be ``none`` and ``numberOfPlanes`` must be ``1``.
+   **Note:** Multiplane modes are available with RA2.1 and RA2.2. For RA1.3 and RA2.0, ``multiplaneMode`` must be ``none`` and ``numberOfPlanes`` must be ``1``.
 
-`Example Spectrum-X NicConfigurationTemplate with multiplane <docs/examples/spectrum-x/example-nicconfigurationtemplate-spectrum-x-multiplane.yaml>`__:
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+Example: Single Plane on BlueField-3 SuperNIC
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 .. code:: yaml
 
    apiVersion: configuration.net.nvidia.com/v1alpha1
    kind: NicConfigurationTemplate
    metadata:
-     name: spectrum-x-multiplane-configuration
+     name: spectrum-x-none-configuration
      namespace: nvidia-network-operator
    spec:
      nodeSelector:
          feature.node.kubernetes.io/network-sriov.capable: "true"
      nicSelector:
-         nicType: "1023" # ConnectX-8. Use "1025" for ConnectX-9, or "a2dc" for BlueField-3 SuperNIC (hwplb not supported on BF3)
+         nicType: "a2dc" # BlueField-3 SuperNIC
          # partNumbers:
-         #   - "MCX713106AEHEA_QP1"
+         #   - "900-9D3B6-00CV-AA0"
      template:
          numVfs: 1
          linkType: Ethernet
          spectrumXOptimized:
              enabled: true
-             version: "RA2.1"
+             version: "RA2.2"
              overlay: "none"
-             multiplaneMode: "hwplb" # Hardware Packet Load Balancing, ConnectX-8 only
+             multiplaneMode: "none" # Single plane, BlueField-3 SuperNIC
+             numberOfPlanes: 1
+
+Example: Software Multiplane (``swplb``) on ConnectX-8 SuperNIC
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+.. code:: yaml
+
+   apiVersion: configuration.net.nvidia.com/v1alpha1
+   kind: NicConfigurationTemplate
+   metadata:
+     name: spectrum-x-swplb-configuration
+     namespace: nvidia-network-operator
+   spec:
+     nodeSelector:
+         feature.node.kubernetes.io/network-sriov.capable: "true"
+     nicSelector:
+         nicType: "1023" # ConnectX-8 SuperNIC
+         # partNumbers:
+         #   - "900-9X81E-00EX-DT0"
+     template:
+         numVfs: 1
+         linkType: Ethernet
+         spectrumXOptimized:
+             enabled: true
+             version: "RA2.2"
+             overlay: "none"
+             multiplaneMode: "swplb" # Software Plane Load Balancing, ConnectX-8 SuperNIC
+             numberOfPlanes: 2
+
+Example: Hardware Multiplane (``hwplb``, tech preview) on ConnectX-8 SuperNIC
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+.. code:: yaml
+
+   apiVersion: configuration.net.nvidia.com/v1alpha1
+   kind: NicConfigurationTemplate
+   metadata:
+     name: spectrum-x-hwplb-configuration
+     namespace: nvidia-network-operator
+   spec:
+     nodeSelector:
+         feature.node.kubernetes.io/network-sriov.capable: "true"
+     nicSelector:
+         nicType: "1023" # ConnectX-8 SuperNIC (hwplb supported on ConnectX-8 SuperNIC only)
+         # partNumbers:
+         #   - "900-9X81E-00EX-DT0"
+     template:
+         numVfs: 1
+         linkType: Ethernet
+         spectrumXOptimized:
+             enabled: true
+             version: "RA2.2"
+             overlay: "none"
+             multiplaneMode: "hwplb" # Hardware Plane Load Balancing (tech preview), ConnectX-8 SuperNIC only
              numberOfPlanes: 4


### PR DESCRIPTION
Cleans up the Spectrum-X NIC matrix and naming, which had drifted between the
26.4.0 pages, to match `docs/spectrum-x/spectrum-x-configuration.rst`.

- **DRA SR-IOV driver** — added a Tech Preview note (it wasn't flagged anywhere).
- **Launch Kit** — fixed the NIC Type Constraints table (missing ConnectX-7 NIC,
  ConnectX-8 SuperNIC naming + `none` mode, `hwplb` tech preview), tidied naming
  throughout (incl. mermaid diagrams), added the `1021` deviceID to the config
  reference, and rewrote the cryptic `uniplane` description.
- **NIC Config Operator** — brought the RA2.1-era Configuration Details page up
  to RA2.2: dropped ConnectX-9, added ConnectX-7 NIC, scoped `swplb`/`hwplb`/
  `uniplane` to ConnectX-8 SuperNIC, renamed "Packet" → "Plane" Load Balancing,
  marked `hwplb` tech preview, and replaced the single example with three
  (single-plane on BF-3, swplb and hwplb on CX-8).

Worth knowing:
- `configuration-details.rst` is generated from the `nic-configuration-operator`
  README — this is a stopgap until the README gets the same fix (following up
  separately).
- Left the Launch Kit auto-default mode/plane mapping alone on purpose; it
  defaults CX-7/BF-3 to `uniplane`, which the operator CRD rejects — that's a
  tool-side fix.

Examples checked against the operator CRD and Launch Kit templates at the 26.4.0
tag; part numbers verified against NVIDIA docs. Renders clean.
