### PR TITLE
fix: push docs branch to fork instead of using gh repo sync

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -53,7 +53,7 @@ jobs:
         git config user.name  nvidia-ci-cd
         git config user.email svc-cloud-orch-gh@nvidia.com
         gh repo fork --remote --default-branch-only
-        gh repo sync $DOWNSTREAM_REPO_OWNER/${{ github.event.repository.name }} --source $UPSTREAM_REPO_OWNER/${{ github.event.repository.name }} --branch $DOCS_BRANCH
+        git push --force origin HEAD:$DOCS_BRANCH
 
         git checkout -b $DOWNSTREAM_FEATURE_BRANCH
         git status


### PR DESCRIPTION
gh repo sync uses the GitHub merge-upstream API which returns 404 when the target branch does not exist in the fork. Replace it with a direct git push --force to create or update the branch as needed.