### PR TITLE
docs/spectrum-x: remove cancelled RA 2.2, fall back to RA 2.1 (Tech Preview on 26.4.x)

### DIFF
--- a/docs/k8s-launch-kit/reference/cli.rst
+++ b/docs/k8s-launch-kit/reference/cli.rst
@@ -108,13 +108,13 @@ Profile Selection
    * - ``--multirail``
      - Enable multirail deployment. Auto-defaults to ``true``. Opt out with ``--multirail=false`` (YAML cannot express explicit-false).
    * - ``--spectrum-x <RA-version>``
-     - Enable Spectrum-X. Value is the SPC-X RA version: ``RA2.1`` or ``RA2.2``. Implies ethernet fabric, sriov deployment, and multirail.
+     - Enable Spectrum-X. Value is the SPC-X RA version: ``RA2.1``. Implies ethernet fabric, sriov deployment, and multirail.
    * - ``--multiplane-mode <string>``
      - Multiplane mode: ``swplb``, ``hwplb``, ``uniplane``, or ``none``. Required with ``--spectrum-x``; auto-defaulted from east-west PF deviceID when omitted (CX7/BF3 → ``uniplane``, CX8 → ``swplb``, CX9 → ``hwplb``). ``none`` requires ``--number-of-planes 1``.
    * - ``--number-of-planes <int>``
      - Number of planes: ``1``, ``2``, or ``4``. Required with ``--spectrum-x``; auto-defaulted from deviceID (CX7/BF3 → 1, CX8 → 2, CX9 → 4).
    * - ``--network-operator-release <string>``
-     - Pin to a Network Operator release line. Supported: ``25.10``, ``26.1``, ``26.4``. Auto-defaulted under ``--spectrum-x`` (``RA2.1`` → ``26.1``; ``RA2.2`` → ``26.4``). See :doc:`../overview`.
+     - Pin to a Network Operator release line. Supported: ``25.10``, ``26.1``, ``26.4``. Auto-defaulted under ``--spectrum-x`` (``RA2.1`` → ``26.1``). See :doc:`../overview`.
    * - ``--groups <a,b,...>``
      - Restrict output to the named source groups (comma-separated, matched case-sensitively against ``clusterConfig[].identifier``). Mutually exclusive with ``--gpu-type``. Empty match is a validation error. See :doc:`../heterogeneous-clusters`.
    * - ``--gpu-type <string>``

--- a/docs/k8s-launch-kit/reference/config.rst
+++ b/docs/k8s-launch-kit/reference/config.rst
@@ -317,7 +317,7 @@ Profile selection (also overridable via CLI flags).
    * - ``multirail``
      - Enable multirail.
    * - ``spectrumX.spcxVersion``
-     - Spectrum-X reference architecture (``RA2.1`` or ``RA2.2``).
+     - Spectrum-X reference architecture (``RA2.1``).
    * - ``spectrumX.multiplaneMode``
      - Multiplane mode: ``hwplb``, ``swplb``, ``uniplane``, ``none``.
    * - ``spectrumX.numberOfPlanes``

--- a/docs/k8s-launch-kit/workflows/generate.rst
+++ b/docs/k8s-launch-kit/workflows/generate.rst
@@ -77,7 +77,7 @@ When a flag is unset on both the CLI and in the configuration file, ``l8k genera
      - 1 (CX7 / BF3 SuperNIC), 2 (CX8), 4 (CX9)
      - only when ``--spectrum-x`` is set
    * - ``--network-operator-release``
-     - matching release for the chosen RA (RA2.1 → 26.1, RA2.2 → 26.4)
+     - matching release for the chosen RA (RA2.1 → 26.1)
      - only when ``--spectrum-x`` is set
 
 Each applied default is logged at info level (``Defaulted --multiplane-mode=swplb (ConnectX-8 (deviceID 1023))``); the full reasoning trail is at debug level (``--log-level debug``).
@@ -99,7 +99,7 @@ For Spectrum-X profiles --- and recommended for all deployments --- pin the Netw
        --fabric ethernet --deployment-type sriov --multirail \
        --save-deployment-files ./deployments
 
-Supported release lines: ``26.1`` and ``26.4``. The release auto-fills versions and image tags from an embedded catalog. RA2.1 Spectrum-X requires ``--network-operator-release 26.1``; RA2.2 Spectrum-X requires ``26.4``.
+Supported release lines: ``26.1`` and ``26.4``. The release auto-fills versions and image tags from an embedded catalog. RA2.1 Spectrum-X requires ``--network-operator-release 26.1``.
 
 ================================================================================
 Generation without a Live Cluster

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -35,7 +35,7 @@ A Helm chart is provided for easily deploying the Network operator in a cluster 
    **What's new in 26.4.0**
 
    * **KubeVirt SR-IOV passthrough** — accelerated East-West networking for VM workloads on vanilla Kubernetes. See :doc:`KubeVirt SR-IOV Integration <kubevirt>`.
-   * **Spectrum-X RA 2.2 alignment** — multi-plane fabric with topology-aware pod placement via DRA, plus simplified config generation through the K8s LaunchKit.
+   * **Spectrum-X RA 2.1 alignment (Tech Preview on 26.4.x)** — multi-plane fabric with topology-aware pod placement via DRA, plus simplified config generation through the K8s LaunchKit.
    * **Dynamic Resource Allocation (DRA) SR-IOV driver** — Kubernetes-native VF allocation for SR-IOV workloads. See :doc:`DRA SR-IOV Driver <dra-sriov-driver/dra-sriov-driver>`.
 
    For the full list of changes, see the :doc:`release-notes`.

--- a/docs/platform-support.rst
+++ b/docs/platform-support.rst
@@ -336,7 +336,7 @@ Supported Container Runtimes
 ==============================================
 NVIDIA Spectrum-X Ethernet Networking Platform
 ==============================================
-**NVIDIA Network Operator** has been validated with the following NVIDIA Spectrum-X Reference Architecture (RA) versions:
+**NVIDIA Network Operator** supports the following NVIDIA Spectrum-X Reference Architecture (RA) versions. On Network Operator 26.4.x, Spectrum-X RA 2.1 is **Tech Preview** — available for early evaluation but not a validated or production-ready (GA) solution. The validated, generally available Spectrum-X RA 2.1 solution is Network Operator 26.1.x; see the `NVIDIA Spectrum-X Validated Solution Stack <https://networking-docs.nvidia.com/software/spectrumx-solution-stack>`_.
 
 .. note::
 
@@ -346,18 +346,13 @@ NVIDIA Spectrum-X Ethernet Networking Platform
    :header-rows: 1
 
    * - Spectrum-X RA Version
+     - Support Level
      - Topologies and NIC Hardware
      - Kubernetes Versions
      - Operating Systems
      - Notes
-   * - 2.2
-     - * Single-Plane (ConnectX-7 or BlueField-3 SuperNIC)
-       * Dual- or Quad-plane (NVIDIA ConnectX-8 SuperNIC)
-     - Upstream Kubernetes (1.31–1.36)
-     - * Ubuntu 24.04 LTS
-       * Ubuntu 22.04 LTS
-     - Small RA, Software Multi-Plane
    * - 2.1
+     - Tech Preview on 26.4.x (GA on 26.1.x)
      - * Single-Plane (ConnectX-7 or BlueField-3 SuperNIC)
        * Dual- or Quad-plane (NVIDIA ConnectX-8 SuperNIC)
      - Upstream Kubernetes (1.31–1.36)

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -46,7 +46,7 @@ Changes and New Features
      - | - Added support for Kubernetes 1.35
        | - Added support for Red Hat OpenShift 4.21
        | - Added support for NVIDIA GB300 NVL72 (DGX/HGX) systems
-       | - Added support for NVIDIA Spectrum-X Reference Architecture 2.2 (RA 2.2) in NVIDIA Spectrum-X Operator, with unified configuration and the new ``SpectrumXRailPoolConfig`` v1alpha2 CRD
+       | - Added a new unified Spectrum-X configuration workflow (the ``SpectrumXRailPoolConfig`` v1alpha2 CRD in NVIDIA Spectrum-X Operator) providing Tech Preview support for Spectrum-X RA 2.1; the generally available (GA) Spectrum-X RA 2.1 workflow is provided in Network Operator 26.1.x
        | - Added IPv6 support for Spectrum-X on Kubernetes
        | - Added consistent naming of RDMA and network devices in Pods
        | - Added RDMA CNI host-to-Pod QoS propagation

--- a/docs/spectrum-x/components.rst
+++ b/docs/spectrum-x/components.rst
@@ -135,14 +135,14 @@ Driver
    * - **DOCA-Host**
      - Host-installed NVIDIA OFED kernel modules and DOCA tooling.
        Includes OVS-DOCA (see :ref:`host-virtual-switch` below). Default
-       driver path for Spectrum-X RA 2.2 validated deployments.
+       driver path for Spectrum-X RA 2.1 (Tech Preview on 26.4.x) deployments.
 
 .. important::
 
    **DOCA-Host (host-installed)** and the **containerized DOCA-OFED
    driver** (deployed via Network Operator — see
    :ref:`k8s-driver-layer`) are **mutually exclusive**. Choose one per
-   node; do not deploy both. Spectrum-X RA 2.2 validated deployments
+   node; do not deploy both. Spectrum-X RA 2.1 (Tech Preview on 26.4.x) deployments
    typically use host-installed DOCA-Host.
 
 .. _host-virtual-switch:

--- a/docs/spectrum-x/quick-start-hwplb.rst
+++ b/docs/spectrum-x/quick-start-hwplb.rst
@@ -28,9 +28,10 @@ Hardware Multiplane Spectrum-X Quick Start (Tech Preview)
 
 .. warning::
 
-   Hardware Multiplane (``hwplb``) is **tech preview** in Network Operator
-   26.4.0 and is **not part of the validated Spectrum-X Reference
-   Architecture**. Use only for evaluation purposes.
+   Hardware Multiplane (``hwplb``) is **tech preview**, planned for a future
+   Spectrum-X Reference Architecture, and is **not part of the current
+   validated Spectrum-X Reference Architecture**. Use only for evaluation
+   purposes.
 
 .. note::
 
@@ -44,7 +45,7 @@ the hardware layer, so each rail still uses a single ``CIDRPool`` while
 exposing multiple per-plane PFs. Used on **B300**
 and **GB300** platforms — set ``numberOfPlanes: 2`` for Dual-Plane or
 ``numberOfPlanes: 4`` for Quad-Plane (B300 only). The configuration uses
-RA 2.2 with ``multiplaneMode: hwplb``. The example below uses
+RA 2.1 with ``multiplaneMode: hwplb``. The example below uses
 ``numberOfPlanes: 2``. Replace ``TODO_*`` values with your cluster-specific
 values before applying.
 
@@ -162,7 +163,7 @@ Map PCI addresses to rail/plane indices and define interface naming. Replace ``T
 Step 4: NicConfigurationTemplate
 ==================================
 
-Configure the ConnectX-8 SuperNICs for Spectrum-X RA 2.2 with ``hwplb`` multiplane mode. ``hwplb`` requires ConnectX-8 SuperNIC (``nicType: 1023``); it is not supported on BlueField-3 SuperNIC or ConnectX-7 NIC. For Quad-Plane (B300 only), set ``numberOfPlanes: 4``.
+Configure the ConnectX-8 SuperNICs for Spectrum-X RA 2.1 with ``hwplb`` multiplane mode. ``hwplb`` requires ConnectX-8 SuperNIC (``nicType: 1023``); it is not supported on BlueField-3 SuperNIC or ConnectX-7 NIC. For Quad-Plane (B300 only), set ``numberOfPlanes: 4``.
 
 .. code-block:: yaml
 
@@ -181,7 +182,7 @@ Configure the ConnectX-8 SuperNICs for Spectrum-X RA 2.2 with ``hwplb`` multipla
        linkType: Ethernet
        spectrumXOptimized:
          enabled: true
-         version: "RA2.2"
+         version: "RA2.1"
          overlay: "none"
          multiplaneMode: "hwplb"
          numberOfPlanes: 2

--- a/docs/spectrum-x/quick-start-single-plane.rst
+++ b/docs/spectrum-x/quick-start-single-plane.rst
@@ -26,6 +26,15 @@ Single-Plane Spectrum-X Quick Start
    :local:
    :backlinks: none
 
+.. warning::
+
+   On Network Operator 26.4.x, this Spectrum-X RA 2.1 configuration workflow is
+   **Tech Preview** — intended for early evaluation of new configuration flows
+   and capabilities, not for production use. The validated, generally available
+   Spectrum-X RA 2.1 solution is Network Operator 26.1.x (see the `NVIDIA
+   Spectrum-X Validated Solution Stack
+   <https://networking-docs.nvidia.com/software/spectrumx-solution-stack>`_).
+
 .. note::
 
    You can automate the configuration of this use case with NVIDIA Kubernetes Launch Kit.
@@ -37,7 +46,7 @@ one PF per rail, one ``CIDRPool`` per rail, one network per rail. Used on
 **GB200 NVL72** platforms (ConnectX-7 NIC, ``nicType: 1021``).
 **ConnectX-8 SuperNIC** (``nicType: 1023``) also supports single-plane configuration —
 useful if you want a single-plane setup on B300/GB300 hardware. The
-configuration uses RA 2.2 with ``multiplaneMode: none`` and
+configuration uses RA 2.1 with ``multiplaneMode: none`` and
 ``numberOfPlanes: 1``. The example below uses BlueField-3 SuperNIC; change
 ``nicType`` for other NICs. Replace ``TODO_*`` values with your
 cluster-specific values before applying.
@@ -158,7 +167,7 @@ Map PCI addresses to rails and define interface naming. With single-plane config
 Step 4: NicConfigurationTemplate
 ==================================
 
-Configure the NICs for Spectrum-X RA 2.2 in single-plane mode. Use ``nicType: a2dc`` for BlueField-3 SuperNIC (HGX H100/H200/B200), ``nicType: 1021`` for ConnectX-7 NIC (GB200), or ``nicType: 1023`` for ConnectX-8 SuperNIC.
+Configure the NICs for Spectrum-X RA 2.1 in single-plane mode. Use ``nicType: a2dc`` for BlueField-3 SuperNIC (HGX H100/H200/B200), ``nicType: 1021`` for ConnectX-7 NIC (GB200), or ``nicType: 1023`` for ConnectX-8 SuperNIC.
 
 .. code-block:: yaml
 
@@ -177,7 +186,7 @@ Configure the NICs for Spectrum-X RA 2.2 in single-plane mode. Use ``nicType: a2
        linkType: Ethernet
        spectrumXOptimized:
          enabled: true
-         version: "RA2.2"
+         version: "RA2.1"
          overlay: "none"
          multiplaneMode: "none"
          numberOfPlanes: 1

--- a/docs/spectrum-x/quick-start-swplb.rst
+++ b/docs/spectrum-x/quick-start-swplb.rst
@@ -26,6 +26,15 @@ Software Multiplane Spectrum-X Quick Start
    :local:
    :backlinks: none
 
+.. warning::
+
+   On Network Operator 26.4.x, this Spectrum-X RA 2.1 configuration workflow is
+   **Tech Preview** — intended for early evaluation of new configuration flows
+   and capabilities, not for production use. The validated, generally available
+   Spectrum-X RA 2.1 solution is Network Operator 26.1.x (see the `NVIDIA
+   Spectrum-X Validated Solution Stack
+   <https://networking-docs.nvidia.com/software/spectrumx-solution-stack>`_).
+
 .. note::
 
    You can automate the configuration of this use case with NVIDIA Kubernetes Launch Kit.
@@ -37,7 +46,7 @@ is split into multiple PFs, each assigned to a separate plane, and the
 software stack performs **Software Plane Load Balancing** (``swplb``) across
 them. Used on **B300** and **GB300** platforms — set ``numberOfPlanes: 2``
 for Dual-Plane or ``numberOfPlanes: 4`` for Quad-Plane (B300 only). The
-configuration uses RA 2.2 with ``multiplaneMode: swplb``. The example below
+configuration uses RA 2.1 with ``multiplaneMode: swplb``. The example below
 uses ``numberOfPlanes: 2``. Replace ``TODO_*`` values with your
 cluster-specific values before applying.
 
@@ -157,7 +166,7 @@ Map PCI addresses to rail/plane indices and define interface naming. Replace ``T
 Step 4: NicConfigurationTemplate
 ==================================
 
-Configure the ConnectX-8 SuperNICs for Spectrum-X RA 2.2 with ``swplb`` multiplane mode. For Quad-Plane (B300 only), set ``numberOfPlanes: 4``.
+Configure the ConnectX-8 SuperNICs for Spectrum-X RA 2.1 with ``swplb`` multiplane mode. For Quad-Plane (B300 only), set ``numberOfPlanes: 4``.
 
 .. code-block:: yaml
 
@@ -176,7 +185,7 @@ Configure the ConnectX-8 SuperNICs for Spectrum-X RA 2.2 with ``swplb`` multipla
        linkType: Ethernet
        spectrumXOptimized:
          enabled: true
-         version: "RA2.2"
+         version: "RA2.1"
          overlay: "none"
          multiplaneMode: "swplb"
          numberOfPlanes: 2

--- a/docs/spectrum-x/quick-start.rst
+++ b/docs/spectrum-x/quick-start.rst
@@ -22,16 +22,21 @@ Spectrum-X Kubernetes Quick Start
 
 .. note::
 
-   These walkthroughs target **Spectrum-X RA 2.2** on **Network Operator 26.4.0**.
-   For the RA-to-release mapping and other RAs, see
+   These walkthroughs target **Spectrum-X RA 2.1** on **Network Operator 26.4.x**,
+   where the Spectrum-X configuration workflow is **Tech Preview**. The fully
+   generally available (GA) Spectrum-X RA 2.1 workflow is provided in
+   **Network Operator 26.1.x**. The 26.4.x workflow shown here is DRA-based
+   (``SpectrumXRailPoolConfig`` ``v1alpha2``); the GA 26.1.x workflow uses the
+   SR-IOV Network Operator with ``OVSNetwork`` and ``SpectrumXRailPoolConfig``
+   ``v1alpha1``. For the RA-to-release mapping and other RAs, see
    :doc:`NVIDIA Spectrum-X <spectrum-x>`. For supported platforms (operating
    systems, Kubernetes distributions, NIC hardware), see
    :doc:`Platform Support <../platform-support>`.
 
-   On Network Operator 26.4.0, **Single-Plane** and **Software Multiplane**
-   (``swplb``) deployments on BlueField-3 SuperNICs, ConnectX-7 NICs, and
-   ConnectX-8 SuperNICs are GA. **Hardware Multiplane** (``hwplb``) is tech
-   preview only and is not part of the validated Spectrum-X Reference
+   On Network Operator 26.4.x, **Single-Plane** and **Software Multiplane**
+   (``swplb``) Spectrum-X deployments (RA 2.1) are **Tech Preview** — intended
+   for early evaluation, not production use. **Hardware Multiplane**
+   (``hwplb``) is tech preview only and is not part of the validated Spectrum-X Reference
    Architecture. For background on the operators and CNIs each walkthrough
    relies on, see :doc:`Architecture and Components <components>`.
 

--- a/docs/spectrum-x/spectrum-x-configuration.rst
+++ b/docs/spectrum-x/spectrum-x-configuration.rst
@@ -28,13 +28,13 @@ NVIDIA Spectrum-X NIC Configuration
    :backlinks: none
 
 
-`NVIDIA NIC Configuration Operator <https://github.com/Mellanox/nic-configuration-operator>`_ in Network Operator 26.4.0 supports **Spectrum-X RA 2.2** as the validated reference architecture. The ``spectrumXOptimized.version`` CRD field also accepts **RA 1.3**, **RA 2.0**, and **RA 2.1** for legacy or mixed-version configurations. RA 2.1 introduced multiplane mode support for enhanced network performance with multiple data planes; **RA 2.2 is the latest** and the validated default.
+`NVIDIA NIC Configuration Operator <https://github.com/Mellanox/nic-configuration-operator>`_ in Network Operator **26.4.x** supports Spectrum-X **RA 2.1** as **Tech Preview (non-GA)** — available for early evaluation of new configuration flows and capabilities, but not a validated or production-ready solution. The validated, generally available Spectrum-X RA 2.1 solution is **Network Operator 26.1.x** (see the `NVIDIA Spectrum-X Validated Solution Stack <https://networking-docs.nvidia.com/software/spectrumx-solution-stack>`_). The ``spectrumXOptimized.version`` CRD field also accepts **RA 1.3** and **RA 2.0** for legacy or mixed-version configurations. RA 2.1 introduced multiplane mode support for enhanced network performance with multiple data planes.
 
 For the Network Operator Spectrum-X RA support matrix and validated hardware, operating system, and Kubernetes combinations, see :doc:`Platform Support <../platform-support>`.
 
 .. note::
 
-   Currently, ConnectX-7 NIC (device ID ``1021``), ConnectX-8 SuperNIC (device ID ``1023``), and BlueField-3 SuperNIC (device ID ``a2dc``) devices are supported for Spectrum-X configuration. Hardware Plane Load Balancing (``hwplb``) is supported only on ConnectX-8 SuperNIC with RA 2.2, and is **tech preview** — it is not part of the validated Spectrum-X Reference Architecture.
+   Currently, ConnectX-7 NIC (device ID ``1021``), ConnectX-8 SuperNIC (device ID ``1023``), and BlueField-3 SuperNIC (device ID ``a2dc``) devices are supported for Spectrum-X configuration. Hardware Plane Load Balancing (``hwplb``) is **tech preview**, planned for a future Spectrum-X Reference Architecture — it is not part of the current validated Spectrum-X Reference Architecture.
 
 
 ====================================================
@@ -42,6 +42,15 @@ Install and Configure the NIC Configuration Operator
 ====================================================
 
 To install the operator and for more information on the CRDs, see :doc:`NIC Firmware Configuration <../nic-conf-operator/nic-fw-configuration>` and :doc:`Configuration Details <../nic-conf-operator/configuration-details>`.
+
+.. note::
+
+   The NIC Configuration Operator reference describes the operator's full CRD
+   capability surface and may list NIC types (for example, ConnectX-9) or
+   multiplane modes (for example, ``hwplb``) that are not part of a given
+   validated Spectrum-X Reference Architecture. For the NIC types and modes
+   validated for Spectrum-X RA 2.1, use the tables on this page together with the
+   `NVIDIA Spectrum-X Validated Solution Stack <https://networking-docs.nvidia.com/software/spectrumx-solution-stack>`_.
 
 =============================================
 Provision the DOCA SPC-X CC Algorithm Package
@@ -83,15 +92,15 @@ Enable SPC-X Optimizations for Devices
     :lines: 18-
 
 
-RA2.1 / RA2.2 configuration with multiplane support
+RA2.1 configuration with multiplane support
 ----------------------------------------------------
 
-Reference Architecture 2.1 introduced multiplane mode support, allowing NICs to be configured with multiple data planes for enhanced network performance. RA2.2 extends this support and is the latest supported version.
+Reference Architecture 2.1 introduced multiplane mode support, allowing NICs to be configured with multiple data planes for enhanced network performance. It is the latest supported version.
 
 .. note::
    It is recommended to perform a NIC configuration reset before applying or switching between multiplane configurations to ensure a clean and consistent initial state. See :doc:`Reset NIC Configuration to Default <../nic-conf-operator/nic-fw-configuration>` for details.
 
-To enable multiplane support, set ``spectrumXOptimized.version`` to ``RA2.1`` or ``RA2.2`` and configure the ``multiplaneMode`` and ``numberOfPlanes`` fields.
+To enable multiplane support, set ``spectrumXOptimized.version`` to ``RA2.1`` and configure the ``multiplaneMode`` and ``numberOfPlanes`` fields.
 
 .. rli:: https://raw.githubusercontent.com/Mellanox/nic-configuration-operator/refs/tags/network-operator-|network-operator-version|/docs/examples/spectrum-x/example-nicconfigurationtemplate-spectrum-x-multiplane.yaml
     :language: yaml
@@ -100,7 +109,7 @@ To enable multiplane support, set ``spectrumXOptimized.version`` to ``RA2.1`` or
 Multiplane modes
 ^^^^^^^^^^^^^^^^
 
-The following multiplane modes are available with RA2.1 and RA2.2:
+The following multiplane modes are available with RA2.1:
 
 .. list-table::
    :header-rows: 1
@@ -119,17 +128,17 @@ The following multiplane modes are available with RA2.1 and RA2.2:
      - ConnectX-8 SuperNIC
      - 2, 4
    * - ``hwplb`` *(tech preview)*
-     - Hardware Plane Load Balancing. Uses hardware LAG resource allocation and NIC-level plane configuration to distribute packets across planes in the NIC hardware. RA 2.2 only. **Tech preview; not part of the validated Reference Architecture.**
+     - Hardware Plane Load Balancing. Uses hardware LAG resource allocation and NIC-level plane configuration to distribute packets across planes in the NIC hardware. **Tech preview; planned for a future Spectrum-X Reference Architecture and not part of the current validated Reference Architecture.**
      - ConnectX-8 SuperNIC
      - 2, 4
    * - ``uniplane``
-     - Uniplane mode. Single-plane physical topology that uses the Spectrum-X multi-plane software stack and IP schema — multiple PFs all connect to the **same** ToR/plane (rather than separate planes as in ``swplb`` / ``hwplb``). Specialized configuration for compatibility or regression scenarios; for production deployments, use ``none`` for Single-Plane or ``swplb`` / ``hwplb`` for Dual-Plane / Quad-Plane.
+     - Uniplane mode. Single-plane physical topology that uses the Spectrum-X multi-plane software stack and IP schema — multiple PFs all connect to the **same** ToR/plane (rather than separate planes as in ``swplb`` / ``hwplb``). Specialized configuration for compatibility or regression scenarios; for production deployments, use ``none`` for Single-Plane or ``swplb`` / ``hwplb`` for Dual-Plane / Quad-Plane. Verify its availability and applicability against the NVIDIA Spectrum-X Reference Architecture documentation before use.
      - ConnectX-8 SuperNIC
      - 2
 
 .. note::
 
-   Multiplane modes (``swplb``, ``hwplb``, ``uniplane``) are only supported with RA2.1 and RA2.2. For RA1.3 and RA2.0, ``multiplaneMode`` must be ``none`` and ``numberOfPlanes`` must be ``1``.
+   Multiplane modes (``swplb``, ``hwplb``, ``uniplane``) are only supported with RA2.1. For RA1.3 and RA2.0, ``multiplaneMode`` must be ``none`` and ``numberOfPlanes`` must be ``1``.
 
 NIC type constraints
 ^^^^^^^^^^^^^^^^^^^^
@@ -153,7 +162,7 @@ NIC type constraints
 
 .. warning::
 
-   The ``hwplb`` multiplane mode is supported only on ConnectX-8 SuperNIC (device ID ``1023``) with RA 2.2, and is **tech preview** — it is not part of the validated Spectrum-X Reference Architecture. Attempting to configure ``hwplb`` on BlueField-3 SuperNIC or ConnectX-7 NIC, or with an RA version other than RA 2.2, will be rejected by the API validation.
+   The ``hwplb`` multiplane mode is **tech preview**, planned for a future Spectrum-X Reference Architecture, and is not part of the current validated Reference Architecture. It is supported only on ConnectX-8 SuperNIC (device ID ``1023``); attempting to configure ``hwplb`` on BlueField-3 SuperNIC or ConnectX-7 NIC will be rejected by the API validation.
 
 Configure custom interface names
 ---------------------------------
@@ -223,4 +232,4 @@ The following validation rules are enforced by the API:
 - When ``multiplaneMode`` is ``none``, ``numberOfPlanes`` must be ``1``.
 - When ``multiplaneMode`` is not ``none``, ``numberOfPlanes`` must not be ``1``.
 - When ``version`` is ``RA1.3`` or ``RA2.0``, ``multiplaneMode`` must be ``none`` and ``numberOfPlanes`` must be ``1``.
-- The ``hwplb`` multiplane mode can only be enabled for ConnectX-8 SuperNIC (``nicType: 1023``), and only with ``version: RA 2.2``. ``hwplb`` is tech preview and is not part of the validated Reference Architecture.
+- The ``hwplb`` multiplane mode can only be enabled for ConnectX-8 SuperNIC (``nicType: 1023``). ``hwplb`` is tech preview, planned for a future Spectrum-X Reference Architecture, and is not part of the current validated Reference Architecture.

--- a/docs/spectrum-x/spectrum-x.rst
+++ b/docs/spectrum-x/spectrum-x.rst
@@ -89,20 +89,38 @@ supported by a specific Network Operator release:
 
 .. list-table::
    :header-rows: 1
-   :widths: 50 50
+   :widths: 34 33 33
 
    * - Spectrum-X RA Version
      - NVIDIA Network Operator Release
-   * - Spectrum-X RA 2.2
-     - 26.4.0
+     - Support Level
    * - Spectrum-X RA 2.1
-     - 26.1.0
+     - 26.1.x
+     - GA
+   * - Spectrum-X RA 2.1
+     - 26.4.x
+     - Tech Preview
+
+.. note::
+
+   On Network Operator 26.4.x, the Spectrum-X RA 2.1 configuration workflow is
+   **Tech Preview** — it lets early adopters evaluate new configuration flows
+   and capabilities, but it is **not a validated or production-ready (GA)
+   solution**. The validated, generally available Spectrum-X RA 2.1 solution is
+   **Network Operator 26.1.x**; see the `NVIDIA Spectrum-X Validated Solution Stack <https://networking-docs.nvidia.com/software/spectrumx-solution-stack>`_.
+
+   The two workflows also differ in their configuration surface: the GA 26.1.x
+   solution uses the SR-IOV Network Operator with ``OVSNetwork`` and
+   ``SpectrumXRailPoolConfig`` (``spectrumx.nvidia.com/v1alpha1``), whereas the
+   26.4.x Tech Preview uses the Dynamic Resource Allocation (DRA) flow with
+   ``SpectrumXRailPoolConfig`` (``spectrumx.nvidia.com/v1alpha2``) described
+   below.
 
 While each Network Operator release is **validated end-to-end** with a
 specific Spectrum-X RA version, individual components support a wider range
 of RAs in their configuration CRDs. For example, NIC Configuration Operator
 in 26.4.0 accepts ``spectrumXOptimized.version`` values **RA1.3**, **RA2.0**,
-**RA2.1**, and **RA2.2**. See :doc:`Spectrum-X NIC Configuration
+and **RA2.1**. See :doc:`Spectrum-X NIC Configuration
 <spectrum-x-configuration>` for details.
 
 **Configuration surface.** Network Operator drives Spectrum-X setup through a


### PR DESCRIPTION
Spectrum-X **RA 2.2 was cancelled** (the Spectrum-X team is going straight to RA 2.3). RA 2.2 content had shipped into the published v26.4.x docs, so this removes it and falls back to **RA 2.1** with the correct support level per NetOp release.

## Core messaging
- **Spectrum-X RA 2.1 is GA on NetOp 26.1.x** — this matches the public **Validated Solution Stack** and the **RA 2.1.6 Deployment Guide** (both list NetOp **26.1.0** as validated).
- **NetOp 26.4.x offers RA 2.1 as Tech Preview** — a *new*, DRA-based configuration workflow (`SpectrumXRailPoolConfig` v1alpha2) for early adopters, **not a validated/GA solution**.
- The two workflows differ: **GA 26.1.x = SR-IOV + `OVSNetwork` + `SpectrumXRailPoolConfig` v1alpha1**; **26.4.x TP = DRA + v1alpha2**. Docs now state this.
- **hwplb** = tech preview, planned for a future RA, not part of the current validated RA (confirmed absent from RA 2.1.6).

## What changed (13 files)
**Core Spectrum-X (10):** `spectrum-x`, `spectrum-x-configuration`, `components`, the four quick-starts, `overview`, `platform-support`, `release-notes` — RA 2.2 removed → RA 2.1; Support-Level columns (GA 26.1.x / TP 26.4.x); Validated Solution Stack links; quick-start Tech-Preview banners; `uniplane` + generated-file caveats.

**Launch Kit reference (3):** `reference/cli`, `reference/config`, `workflows/generate` — dropped RA 2.2 from the tool-accurate flag/mapping surfaces (`RA2.1 → 26.1`).

## Deferred on purpose (RA 2.2 intentionally left)
These are **tool-coupled or generated** and will be handled in follow-ups:
- **Launch Kit profile-catalog pages** (`k8s-launch-kit/overview`, `profiles/spectrum-x`, `profiles/profiles`) and **`ai-skills.rst`** — they describe the actual `l8k` `spectrum-x` profile (RA 2.2 / v1alpha2). Editing them desyncs from the tool until a coordinated `k8s-launch-kit` update lands.
- **`nic-conf-operator/configuration-details.rst`** — generated from the upstream `nic-configuration-operator` README (`make fetch-config-docs`); durable fix belongs upstream. A caveat note was added in `spectrum-x-configuration.rst`.

## Known temporary inconsistency
Until the deferred items land, the **core Spectrum-X + CLI/config/generate pages say RA 2.1** while the **Launch Kit profile pages + generated config-details still reference RA 2.2**. This is a conscious, tool-coupled deferral.

## Validation
- Cross-checked against the public **Spectrum-X Validated Solution Stack** and the **RA 2.1.6 Deployment Guide** (incl. K8s appendix): no contradictions on plane support (Single=`none`, Dual/Quad=`swplb`; `hwplb` is future).
- Full styled build (`make gen-docs-docker`) passes; core + reference pages render RA 2.2-free.
