### PR TITLE
docs: use current platform names and NVIDIA IPAM consistently

### DIFF
--- a/docs/deployment-guide-kubernetes.rst
+++ b/docs/deployment-guide-kubernetes.rst
@@ -435,7 +435,7 @@ Once the Network Operator is installed create a NicClusterPolicy with:
     * Secondary network
     * Multus CNI
     * Container Networking plugins
-    * IPAM plugin
+    * NVIDIA IPAM plugin
 
 .. code-block:: yaml
    :substitutions:
@@ -841,7 +841,7 @@ Once the Network Operator is installed create a NicClusterPolicy with:
     * Secondary network
     * Multus CNI
     * Container Networking plugins
-    * IPAM plugin
+    * NVIDIA IPAM plugin
 
 
 .. code-block:: yaml
@@ -1281,7 +1281,7 @@ Once the Network Operator is installed create a NicClusterPolicy with:
     * Secondary network
     * Multus CNI
     * Container Networking Plugins
-    * IPAM plugin
+    * NVIDIA IPAM plugin
 
 .. code-block:: yaml
    :substitutions:
@@ -1465,7 +1465,7 @@ Once the Network Operator is installed create a NicClusterPolicy with:
     * Secondary network
     * Multus CNI
     * Container Networking plugins
-    * IPAM Plugin
+    * NVIDIA IPAM Plugin
 
 .. code-block:: yaml
    :substitutions:

--- a/docs/nic-conf-operator/nic-fw-configuration.rst
+++ b/docs/nic-conf-operator/nic-fw-configuration.rst
@@ -80,11 +80,11 @@ There are two requirements for the SR-IOV Network Operator to work together with
 
 .. _fw-reset-external-bmc:
 
-=====================================================================
-Platforms with external BMC (DGX, HGX GB200/B200/B300, Vera Rubin GB)
-=====================================================================
+=============================================================================================
+Platforms with external BMC (DGX or HGX GB200/GB300, B200/B300, Vera Rubin NVL72, Rubin NVL8)
+=============================================================================================
 
-On platforms where the NIC is controlled by an external BMC — including NVIDIA DGX and HGX systems (GB200 NVL72, B200, B300) and the Vera Rubin GB family — an OS-level node reboot does **not** reload NIC firmware: the BMC keeps the device powered across the reboot. As a result, persistent firmware parameters set with ``mlxconfig`` are not applied, and the operator stack can end up in a reboot loop trying to converge on the requested configuration.
+On platforms where the NIC is controlled by an external BMC — including NVIDIA DGX or HGX GB200/GB300, B200/B300, Vera Rubin NVL72, and Rubin NVL8 systems — an OS-level node reboot does **not** reload NIC firmware: the BMC keeps the device powered across the reboot. As a result, persistent firmware parameters set with ``mlxconfig`` are not applied, and the operator stack can end up in a reboot loop trying to converge on the requested configuration.
 
 To avoid this, configure both the NIC Configuration Operator and the SR-IOV Network Operator to perform an explicit firmware reset (``mlxfwreset`` / ``mstfwreset``) **before** the reboot. The two settings are independent — enable both when both operators are deployed, or just the one matching the operator you are running.
 
@@ -159,7 +159,7 @@ Install the NIC Configuration Operator and observe NIC devices in the cluster
     To disable the Firmware upgrade and validation logic, do not define the ``nicFirmwareStorage`` section in the NicClusterPolicy CR.
 
 .. note::
-    On platforms where the NIC is controlled by an external BMC (DGX, HGX GB200/B200/B300, Vera Rubin GB), additional configuration is required so that firmware updates are applied without a reboot loop — see :ref:`fw-reset-external-bmc`. The example below shows the relevant ``FW_RESET_AFTER_CONFIG_UPDATE`` knob commented out for reference.
+    On platforms where the NIC is controlled by an external BMC (DGX or HGX GB200/GB300, B200/B300, Vera Rubin NVL72, Rubin NVL8), additional configuration is required so that firmware updates are applied without a reboot loop — see :ref:`fw-reset-external-bmc`. The example below shows the relevant ``FW_RESET_AFTER_CONFIG_UPDATE`` knob commented out for reference.
 
 First install the Network Operator helm chart with the Maintenance Operator enabled and deploy a NIC Cluster Policy CRD with NIC Configuration Operator and DOCA-OFED Driver enabled:
 


### PR DESCRIPTION
Two naming inconsistencies, both mechanical. No prose or structure changes.

## Platform names — `nic-conf-operator/nic-fw-configuration.rst`

The external-BMC section used an internal/legacy platform list in three places (section heading, its intro sentence, and a later `note::`):

- `DGX, HGX GB200/B200/B300, Vera Rubin GB` → `DGX or HGX GB200/GB300, B200/B300, Vera Rubin NVL72, Rubin NVL8`

The heading's over/underline was extended to match the longer title. The `_fw-reset-external-bmc` anchor is unchanged, so the cross-reference from the `note::` still resolves.

## NVIDIA IPAM — `deployment-guide-kubernetes.rst`

Four component lists said bare `IPAM plugin` while three others in the same file already said `NVIDIA IPAM`, leaving the page inconsistent with itself and implying an IPAM choice exists. NV-IPAM is the only supported IPAM in Network Operator, so all seven now read the same. Per-line capitalisation is preserved to keep the diff to the one word.

## Verification

`make gen-docs-docker` builds clean with no new Sphinx warnings.

## Note

One further platform-name fix — `dra-sriov-driver.rst`'s `pcieRoot` warning (`GB300, Vera Rubin, and Fractal`) — is deliberately **not** in this PR. That file also gains new content in the upcoming Spectrum-X RA 2.3 work, and splitting one file across two PRs would conflict. It will land with that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)